### PR TITLE
fix(tts): always send pitch and loudness in TTS request body

### DIFF
--- a/src/sarvam_mcp/tools/tts.py
+++ b/src/sarvam_mcp/tools/tts.py
@@ -66,13 +66,12 @@ def register(mcp: FastMCP) -> None:
             "target_language_code": target_language_code,
             "speaker": speaker,
             "speech_sample_rate": speech_sample_rate,
+            "pitch": pitch,
             "pace": pace,
+            "loudness": loudness,
             "enable_preprocessing": enable_preprocessing,
             "model": model,
         }
-        if model != "bulbul:v3":
-            body["pitch"] = pitch
-            body["loudness"] = loudness
 
         with measure_tool() as metrics:
             payload, call = await sc.client.post_json(TTS_PATH, json_body=body)


### PR DESCRIPTION
## Fixes Issue #16 

## Bug

`sarvam_tools_tts_speak` accepts `pitch` and `loudness` parameters but
silently drops them from every API request.

**Root cause:** An inverted guard condition in `tools/tts.py`:

```python
# Before (buggy)
if model != "bulbul:v3":   # always False — bulbul:v3 is the only allowed value
    body["pitch"] = pitch
    body["loudness"] = loudness
```
Since TtsModel = Literal["bulbul:v3"] (line 20), the condition
model != "bulbul:v3" is always False. As a result, pitch and
loudness were never included in the request body regardless of what
the caller specified.

## Fix 

Remove the guard and inline pitch and loudness directly in the body dict:
```python
body: dict[str, Any] = {
    "inputs": [text],
    "target_language_code": target_language_code,
    "speaker": speaker,
    "speech_sample_rate": speech_sample_rate,
    "pitch": pitch,
    "pace": pace,
    "loudness": loudness,
    "enable_preprocessing": enable_preprocessing,
    "model": model,
}
```

## Impact
Every call to sarvam_tools_tts_speak was affected. Users setting
custom pitch or loudness values would always get the API default
behaviour with no indication their parameters were being ignored.



