### PR TITLE
fix translate/transliterate auto-detect: map "unknown" to "auto"

### DIFF
--- a/src/sarvam_mcp/code/_data.py
+++ b/src/sarvam_mcp/code/_data.py
@@ -198,7 +198,7 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
         "content_type": "application/json",
         "request_body": {
             "input":                "str, required",
-            "source_language_code": "str — BCP-47 or 'unknown'",
+            "source_language_code": "str — BCP-47 or 'auto' for auto-detect",
             "target_language_code": "str — BCP-47",
             "model":                "str",
             "mode":                 "str — formal | modern-colloquial | classic-colloquial | code-mixed (Mayura only)",

--- a/src/sarvam_mcp/code/snippets.py
+++ b/src/sarvam_mcp/code/snippets.py
@@ -300,7 +300,7 @@ _VALID_TRANSLATE_MODELS = {"mayura:v1", "sarvam-translate:v1"}
 _VALID_STT_MODELS = {"saaras:v3"}
 _VALID_STT_MODES = {"transcribe", "translate", "verbatim", "translit", "codemix"}
 _VALID_SAARAS_MODELS = {"saaras:v3", "saaras:v3-realtime", "saaras:v2.5"}
-_VALID_LANGUAGE_CODES = {lang["code"] for lang in _data.ALL_LANGUAGES} | {"unknown"}
+_VALID_LANGUAGE_CODES = {lang["code"] for lang in _data.ALL_LANGUAGES} | {"auto", "unknown"}
 _TTS_LANG_CODES = {lang["code"] for lang in _data.LANGUAGES_BY_API["tts"]}
 
 

--- a/src/sarvam_mcp/tools/_common.py
+++ b/src/sarvam_mcp/tools/_common.py
@@ -88,7 +88,11 @@ async def resolve_file_input(
 # ---- Language codes -------------------------------------------------------
 #
 # Sarvam uses BCP-47-style codes with the ISO 639-3 language subtag for
-# constitutionally-listed languages. ``unknown`` lets the API auto-detect.
+# constitutionally-listed languages.
+# Auto-detect: the Translate/Transliterate APIs accept ``"auto"``; STT
+# accepts ``"unknown"``.  Both values are exposed so the agent can use
+# either; tool implementations map to the value the upstream endpoint
+# expects before calling the API.
 
 LanguageCode = Literal[
     "en-IN",  # English
@@ -114,7 +118,8 @@ LanguageCode = Literal[
     "brx-IN",  # Bodo
     "mai-IN",  # Maithili
     "doi-IN",  # Dogri
-    "unknown",  # Auto-detect
+    "auto",  # Auto-detect (Translate / Transliterate APIs)
+    "unknown",  # Auto-detect (STT API, kept for backward compat)
 ]
 
 # Subset that the TTS API (bulbul:v3) supports. STT covers all 23 above.

--- a/src/sarvam_mcp/tools/translate.py
+++ b/src/sarvam_mcp/tools/translate.py
@@ -41,7 +41,7 @@ def register(mcp: FastMCP) -> None:
         ctx: Context,
         input: str = Field(description="Text to translate (max ~2000 chars)."),
         source_language_code: LanguageCode = Field(
-            description="Source BCP-47 code, or 'unknown' to auto-detect.",
+            description="Source BCP-47 code, or 'auto' to auto-detect.",
         ),
         target_language_code: LanguageCode = Field(description="Target BCP-47 code."),
         model: TranslateModel = Field(
@@ -64,9 +64,11 @@ def register(mcp: FastMCP) -> None:
         enable_preprocessing: bool = Field(default=True),
     ) -> dict[str, Any]:
         sc = await ready_ctx(ctx)
+        # Upstream /translate accepts "auto", not "unknown".
+        src = "auto" if source_language_code == "unknown" else source_language_code
         body: dict[str, Any] = {
             "input": input,
-            "source_language_code": source_language_code,
+            "source_language_code": src,
             "target_language_code": target_language_code,
             "model": model,
             "numerals_format": numerals_format,

--- a/src/sarvam_mcp/tools/transliterate.py
+++ b/src/sarvam_mcp/tools/transliterate.py
@@ -28,7 +28,7 @@ def register(mcp: FastMCP) -> None:
         ctx: Context,
         input: str = Field(description="Text to transliterate."),
         source_language_code: LanguageCode = Field(
-            description="Source language code (e.g. 'hi-IN').",
+            description="Source language code (e.g. 'hi-IN'), or 'auto' to auto-detect.",
         ),
         target_language_code: LanguageCode = Field(
             description="Target language code (script of the output).",
@@ -44,9 +44,11 @@ def register(mcp: FastMCP) -> None:
         ),
     ) -> dict[str, Any]:
         sc = await ready_ctx(ctx)
+        # Upstream /transliterate accepts "auto", not "unknown".
+        src = "auto" if source_language_code == "unknown" else source_language_code
         body: dict[str, Any] = {
             "input": input,
-            "source_language_code": source_language_code,
+            "source_language_code": src,
             "target_language_code": target_language_code,
             "numerals_format": numerals_format,
             "spoken_form": spoken_form,

--- a/src/sarvam_mcp/workflows/_helpers.py
+++ b/src/sarvam_mcp/workflows/_helpers.py
@@ -65,9 +65,11 @@ async def translate_text(
     metrics: ToolMetrics | None = None,
 ) -> str:
     """Translate ``text`` and return the translated string."""
+    # Upstream /translate accepts "auto", not "unknown".
+    src = "auto" if source_language_code == "unknown" else source_language_code
     body_req: dict[str, Any] = {
         "input": text,
-        "source_language_code": source_language_code,
+        "source_language_code": src,
         "target_language_code": target_language_code,
         "model": model,
         "numerals_format": "international",


### PR DESCRIPTION
## Summary
- The upstream Sarvam `/translate` and `/transliterate` APIs accept `"auto"` for source-language auto-detection, but the MCP `LanguageCode` enum only exposed `"unknown"` (the STT convention). This mismatch made auto-detect impossible — `"unknown"` was sent as-is and rejected by the API, while `"auto"` was blocked client-side by the enum.
- Adds `"auto"` to the `LanguageCode` enum, keeps `"unknown"` for STT backward compat, and maps `"unknown"` → `"auto"` in translate, transliterate, and the dub workflow helper before calling the upstream API.
- Updates the API reference docs and request validator to accept `"auto"`.