### PR TITLE
fix(tools): close temp file on resolve_file_input download failure

### DIFF
--- a/src/sarvam_mcp/tools/_common.py
+++ b/src/sarvam_mcp/tools/_common.py
@@ -83,6 +83,7 @@ async def resolve_file_input(
             tmp.close()
             yield tmp_path
     finally:
+        tmp.close()
         tmp_path.unlink(missing_ok=True)
 
 # ---- Language codes -------------------------------------------------------

--- a/tests/tools/test_common.py
+++ b/tests/tools/test_common.py
@@ -1,0 +1,55 @@
+"""Tests for shared tool helpers in ``_common`` — currently ``resolve_file_input``."""
+
+from __future__ import annotations
+
+import tempfile
+
+import httpx
+import pytest
+
+from sarvam_mcp.tools._common import resolve_file_input
+
+
+@pytest.fixture
+def capture_tempfiles(monkeypatch):
+    """Capture every ``NamedTemporaryFile`` ``resolve_file_input`` opens."""
+    created = []
+    real = tempfile.NamedTemporaryFile
+
+    def spy(*args, **kwargs):
+        tmp = real(*args, **kwargs)
+        created.append(tmp)
+        return tmp
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", spy)
+    return created
+
+
+async def test_url_download_failure_closes_temp_file(capture_tempfiles, httpx_mock):
+    """A non-2xx download must still close the temp file before cleanup.
+
+    Otherwise the file descriptor leaks (POSIX) and ``tmp_path.unlink`` raises
+    ``PermissionError`` on Windows, masking the original HTTP error.
+    """
+    httpx_mock.add_response(method="GET", url="https://files.example/missing.wav", status_code=404)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        async with resolve_file_input(file_url="https://files.example/missing.wav", filename="missing.wav"):
+            pass
+
+    assert capture_tempfiles, "expected a temp file to have been created"
+    assert capture_tempfiles[0].closed, "temp file was left open after a failed download"
+
+
+async def test_url_download_over_size_limit_closes_temp_file(capture_tempfiles, httpx_mock):
+    """Aborting mid-stream on the size limit must also close the temp file."""
+    httpx_mock.add_response(method="GET", url="https://files.example/big.wav", content=b"x" * 64)
+
+    with pytest.raises(ValueError):
+        async with resolve_file_input(
+            file_url="https://files.example/big.wav", filename="big.wav", max_bytes=16
+        ):
+            pass
+
+    assert capture_tempfiles, "expected a temp file to have been created"
+    assert capture_tempfiles[0].closed, "temp file was left open after exceeding the size limit"


### PR DESCRIPTION
## What

`resolve_file_input` opens a `NamedTemporaryFile(delete=False)` and only calls `tmp.close()` on the success path. When a URL download fails — non-2xx response, the `max_bytes` size limit, or a network error — that close is skipped and control jumps to the `finally`, which runs `tmp_path.unlink(missing_ok=True)` while the file is still open.

- POSIX: the unlink succeeds but the file descriptor stays open until GC, so repeated failed downloads slowly leak fds.
- Windows: `unlink` raises `PermissionError [WinError 32]` because the handle is open. `missing_ok=True` only suppresses `FileNotFoundError`, so the `finally` itself throws, replacing the real `HTTPStatusError` with a confusing `PermissionError` and leaking both the fd and the file on disk.

## Fix

Close `tmp` in the `finally` before `unlink`, so it is always closed first. Closing again on the success path is a no-op, and the existing pre-`yield` closes stay so the file is flushed before the consumer reads it. This one line also covers the base64 over-size branch, which has the same gap.

## Test

Added `tests/tools/test_common.py`. It spies on `NamedTemporaryFile` and asserts the temp file is closed after a failed download — both a 404 (the reported scenario) and a mid-stream size-limit abort. Both fail on `main` (file left open) and pass with the fix. Full suite: 49 passed.

Fixes #16
