### PR TITLE
fix(tools): close temp file on URL download failure

### DIFF
--- a/src/sarvam_mcp/tools/_common.py
+++ b/src/sarvam_mcp/tools/_common.py
@@ -69,18 +69,20 @@ async def resolve_file_input(
             yield tmp_path
         else:
             assert file_url is not None
-            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0)) as client:
-                async with client.stream("GET", file_url) as resp:
-                    resp.raise_for_status()
-                    downloaded = 0
-                    async for chunk in resp.aiter_bytes(chunk_size=65536):
-                        downloaded += len(chunk)
-                        if downloaded > max_bytes:
-                            raise ValueError(
-                                f"Downloaded file exceeds {max_bytes} byte limit."
-                            )
-                        tmp.write(chunk)
-            tmp.close()
+            try:
+                async with httpx.AsyncClient(timeout=httpx.Timeout(120.0)) as client:
+                    async with client.stream("GET", file_url) as resp:
+                        resp.raise_for_status()
+                        downloaded = 0
+                        async for chunk in resp.aiter_bytes(chunk_size=65536):
+                            downloaded += len(chunk)
+                            if downloaded > max_bytes:
+                                raise ValueError(
+                                    f"Downloaded file exceeds {max_bytes} byte limit."
+                                )
+                            tmp.write(chunk)
+            finally:
+                tmp.close()
             yield tmp_path
     finally:
         tmp_path.unlink(missing_ok=True)

--- a/tests/tools/test_common.py
+++ b/tests/tools/test_common.py
@@ -1,0 +1,42 @@
+"""Shared tool-helper tests."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from sarvam_mcp.tools._common import resolve_file_input
+
+
+async def test_resolve_file_input_url_preserves_http_error(httpx_mock):
+    httpx_mock.add_response(
+        method="GET",
+        url="https://example.test/missing.wav",
+        status_code=404,
+        text="not found",
+    )
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        async with resolve_file_input(
+            file_url="https://example.test/missing.wav",
+            filename="missing.wav",
+        ):
+            raise AssertionError("context body should not run")
+
+    assert exc_info.value.response.status_code == 404
+
+
+async def test_resolve_file_input_url_preserves_size_limit_error(httpx_mock):
+    httpx_mock.add_response(
+        method="GET",
+        url="https://example.test/too-large.wav",
+        content=b"abcdef",
+    )
+
+    with pytest.raises(ValueError, match="Downloaded file exceeds"):
+        async with resolve_file_input(
+            file_url="https://example.test/too-large.wav",
+            filename="too-large.wav",
+            max_bytes=3,
+        ):
+            raise AssertionError("context body should not run")


### PR DESCRIPTION
## Summary

Fixes #16.

This closes the temporary file created by `resolve_file_input()` when URL downloads fail before reaching the success path.

Previously, failures from `resp.raise_for_status()`, size-limit checks, or network errors skipped `tmp.close()` and then attempted to unlink the still-open temp file in the outer `finally` block. On Windows this could replace the original error with `PermissionError: [WinError 32]`; on Unix-like systems it could leak the file descriptor until GC.

## Changes

- Wrap the URL download block in `try/finally`.
- Always call `tmp.close()` before the outer cleanup unlinks the temp path.
- Add regression tests for:
  - non-2xx URL responses preserving `httpx.HTTPStatusError`
  - oversized URL downloads preserving the intended `ValueError`

## Testing

- `uv run python -m pytest tests\tools\test_common.py -q`
  - `2 passed`

Full suite was also run:
- `47 passed, 2 failed`

The two failures are unrelated existing Windows config-test failures around `Path("~").expanduser()` using `USERPROFILE` rather than monkeypatched `HOME`.