### PR TITLE
fix(http): report installed version in outbound User-Agent

### DIFF
--- a/src/sarvam_mcp/http/client.py
+++ b/src/sarvam_mcp/http/client.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import httpx
 
+from sarvam_mcp import __version__
 from sarvam_mcp.auth.context import current_auth
 from sarvam_mcp.http.errors import (
     SarvamAPIError,
@@ -25,6 +26,7 @@ from sarvam_mcp.http.retry import retry_async
 from sarvam_mcp.observability import CallMetrics, metrics_from_response_headers
 
 DEFAULT_TIMEOUT = httpx.Timeout(120.0, connect=10.0)
+USER_AGENT = f"sarvam-mcp/{__version__}"
 
 
 class SarvamClient:
@@ -40,7 +42,7 @@ class SarvamClient:
         self._client = httpx.AsyncClient(
             base_url=self._base_url,
             timeout=timeout,
-            headers={"User-Agent": "sarvam-mcp/0.1.0"},
+            headers={"User-Agent": USER_AGENT},
         )
 
     async def aclose(self) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from sarvam_mcp import __version__
 from sarvam_mcp.http import (
     SarvamAPIError,
     SarvamAuthError,
@@ -35,6 +36,21 @@ async def test_auth_header_is_attached(client, httpx_mock):
     assert payload == {"translated_text": "ok"}
     assert metrics.request_id == "req_123"
     assert metrics.status_code == 200
+
+
+async def test_user_agent_reports_package_version(client, httpx_mock):
+    # The outbound User-Agent must track the installed package version so
+    # Sarvam's server-side telemetry attributes traffic to the right release.
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.sarvam.ai/translate",
+        json={"translated_text": "ok"},
+    )
+
+    await client.post_json("/translate", json_body={"input": "hi"})
+
+    request = httpx_mock.get_request()
+    assert request.headers["user-agent"] == f"sarvam-mcp/{__version__}"
 
 
 async def test_401_maps_to_auth_error(client, httpx_mock):


### PR DESCRIPTION
## Summary

`SarvamClient` sends a hardcoded `User-Agent: sarvam-mcp/0.1.0` on **every** outbound request, but the package is currently at **`0.2.4`** (`sarvam_mcp.__version__`). The header literal was never wired to the package version, so it has been frozen at `0.1.0` across every release since.

As a result, every request to `api.sarvam.ai` misreports the client version. That undermines anything that relies on the User-Agent server-side: version/adoption telemetry, "are clients picking up the fix?" tracking, and support debugging (the version in the logs is always wrong).

## The bug

```python
# src/sarvam_mcp/http/client.py
self._client = httpx.AsyncClient(
    base_url=self._base_url,
    timeout=timeout,
    headers={"User-Agent": "sarvam-mcp/0.1.0"},   # ← stale literal, never updated
)
```

## The fix

Derive the header from the single source of truth (`__version__`) so it can never drift again:

```python
from sarvam_mcp import __version__

USER_AGENT = f"sarvam-mcp/{__version__}"
...
headers={"User-Agent": USER_AGENT},
```

(`sarvam_mcp/__init__.py` only defines `__version__` with no imports, so there is no circular-import risk.)

## Tests

Added a regression test that asserts the outbound `User-Agent` tracks the installed version, so a future hardcoded value or version bump that forgets the header will fail CI:

```python
async def test_user_agent_reports_package_version(client, httpx_mock):
    httpx_mock.add_response(method="POST", url="https://api.sarvam.ai/translate",
                            json={"translated_text": "ok"})
    await client.post_json("/translate", json_body={"input": "hi"})
    request = httpx_mock.get_request()
    assert request.headers["user-agent"] == f"sarvam-mcp/{__version__}"
```

Before the fix this test fails with:

```
E  AssertionError: assert 'sarvam-mcp/0.1.0' == 'sarvam-mcp/0.2.4'
```

After the fix, the full client suite passes:

```
tests/test_client.py::test_auth_header_is_attached PASSED                [ 12%]
tests/test_client.py::test_user_agent_reports_package_version PASSED     [ 25%]
tests/test_client.py::test_401_maps_to_auth_error PASSED                 [ 37%]
tests/test_client.py::test_429_maps_to_rate_limit_with_retry_after PASSED [ 50%]
tests/test_client.py::test_400_maps_to_bad_request PASSED               [ 62%]
tests/test_client.py::test_5xx_retries_then_succeeds PASSED             [ 75%]
tests/test_client.py::test_5xx_exhausts_retries PASSED                  [ 87%]
tests/test_client.py::test_binary_response_returned_as_bytes PASSED     [100%]

============================== 8 passed in 2.33s ==============================
```

## Scope / risk

- Touches only `src/sarvam_mcp/http/client.py` (header value) and `tests/test_client.py` (new test).
- No behavior change beyond the corrected header string; no public API change.