### PR TITLE
fix(http): map network failures to a typed SarvamConnectionError

### DIFF
--- a/src/sarvam_mcp/http/__init__.py
+++ b/src/sarvam_mcp/http/__init__.py
@@ -1,6 +1,17 @@
 """Sarvam HTTP client + retry/error primitives."""
 
 from sarvam_mcp.http.client import SarvamClient
-from sarvam_mcp.http.errors import SarvamAPIError, SarvamAuthError, SarvamRateLimitError
+from sarvam_mcp.http.errors import (
+    SarvamAPIError,
+    SarvamAuthError,
+    SarvamConnectionError,
+    SarvamRateLimitError,
+)
 
-__all__ = ["SarvamClient", "SarvamAPIError", "SarvamAuthError", "SarvamRateLimitError"]
+__all__ = [
+    "SarvamClient",
+    "SarvamAPIError",
+    "SarvamAuthError",
+    "SarvamConnectionError",
+    "SarvamRateLimitError",
+]

--- a/src/sarvam_mcp/http/client.py
+++ b/src/sarvam_mcp/http/client.py
@@ -19,6 +19,7 @@ from sarvam_mcp.http.errors import (
     SarvamAPIError,
     SarvamAuthError,
     SarvamBadRequestError,
+    SarvamConnectionError,
     SarvamRateLimitError,
 )
 from sarvam_mcp.http.retry import retry_async
@@ -190,6 +191,17 @@ class SarvamClient:
         except httpx.HTTPStatusError as exc:
             # Retries exhausted — fall through to typed error mapping below.
             response = exc.response
+        except httpx.TransportError as exc:
+            # Connection/DNS/timeout failure, never produced a response (even
+            # after retries). Map to a typed error so tools surface the same
+            # SarvamAPIError contract as HTTP failures instead of a raw httpx
+            # exception.
+            raise SarvamConnectionError(
+                f"Could not reach the Sarvam API ({type(exc).__name__}): {exc}",
+                status_code=None,
+                request_id=None,
+                body=None,
+            ) from exc
         metrics = metrics_from_response_headers(dict(response.headers))
         metrics.status_code = response.status_code
 

--- a/src/sarvam_mcp/http/errors.py
+++ b/src/sarvam_mcp/http/errors.py
@@ -34,3 +34,9 @@ class SarvamRateLimitError(SarvamAPIError):
 
 class SarvamBadRequestError(SarvamAPIError):
     """400 — caller-side validation problem."""
+
+
+class SarvamConnectionError(SarvamAPIError):
+    """Network-level failure (DNS, connection refused, timeout) — the request
+    never produced an HTTP response, even after retries. ``status_code`` is
+    ``None`` since no response was received."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import httpx
 import pytest
 
 from sarvam_mcp.http import (
     SarvamAPIError,
     SarvamAuthError,
     SarvamClient,
+    SarvamConnectionError,
     SarvamRateLimitError,
 )
 from sarvam_mcp.http.errors import SarvamBadRequestError
@@ -102,6 +104,32 @@ async def test_5xx_exhausts_retries(client, httpx_mock):
     with pytest.raises(SarvamAPIError) as exc_info:
         await client.post_json("/translate", json_body={"input": "x"})
     assert exc_info.value.status_code == 503
+
+
+async def test_transport_error_maps_to_connection_error(client, httpx_mock):
+    # A connection/DNS/timeout failure must surface as a typed error, not a
+    # raw httpx exception leaking out of the client.
+    for _ in range(3):  # retry_async runs at most 3 attempts.
+        httpx_mock.add_exception(httpx.ConnectError("connection refused"))
+
+    with pytest.raises(SarvamConnectionError) as exc_info:
+        await client.post_json("/translate", json_body={"input": "x"})
+
+    assert exc_info.value.status_code is None
+    assert "ConnectError" in str(exc_info.value)
+    # The originating httpx error is preserved on the chain.
+    assert isinstance(exc_info.value.__cause__, httpx.ConnectError)
+    assert len(httpx_mock.get_requests()) == 3
+
+
+async def test_connection_error_is_a_sarvam_api_error(client, httpx_mock):
+    # Subclass of SarvamAPIError so existing `except SarvamAPIError` handlers
+    # keep catching network failures.
+    for _ in range(3):
+        httpx_mock.add_exception(httpx.ReadTimeout("timed out"))
+
+    with pytest.raises(SarvamAPIError):
+        await client.post_json("/translate", json_body={"input": "x"})
 
 
 async def test_binary_response_returned_as_bytes(client, httpx_mock):


### PR DESCRIPTION
## Summary

`SarvamClient` maps retried **5xx** responses to a typed `SarvamAPIError`, but a **connection-level failure** (DNS failure, connection refused, connect/read timeout) is never caught in `_do_request`. After retries are exhausted, `retry_async` re-raises the raw `httpx.TransportError`, which leaks all the way out to the calling tool and the MCP agent.

This breaks the contract `http/errors.py` documents:

> Typed errors raised by SarvamClient. Tools surface these to the agent.

So today, under **any** network failure, every tool surfaces a raw `httpx` traceback (e.g. `httpx.ConnectError: ...`) instead of an actionable Sarvam error — inconsistent with how 4xx/5xx are handled.

## Root cause

```python
# src/sarvam_mcp/http/client.py — _do_request
try:
    response = await retry_async(send)
except httpx.HTTPStatusError as exc:   # 5xx after retries → typed error below
    response = exc.response
# ❌ httpx.TransportError (connect/DNS/timeout) is NOT caught → leaks raw
```

`retry_async` deliberately *retries* `httpx.TransportError` (connection-level), which shows the intent to treat it as a transient API failure — but once retries are exhausted it propagates unwrapped.

## Reproduction

With the connection failing on every attempt, the raw httpx error escapes the client:

```python
for _ in range(3):  # retry_async runs at most 3 attempts
    httpx_mock.add_exception(httpx.ConnectError("connection refused"))
await client.post_json("/translate", json_body={"input": "x"})
# Before this PR:
#   httpx.ConnectError: connection refused   ← raw, leaks out of SarvamClient
```

## Fix

Catch `httpx.TransportError` in `_do_request` and raise a new `SarvamConnectionError`:

```python
except httpx.TransportError as exc:
    raise SarvamConnectionError(
        f"Could not reach the Sarvam API ({type(exc).__name__}): {exc}",
        status_code=None, request_id=None, body=None,
    ) from exc
```

`SarvamConnectionError` is a **subclass of `SarvamAPIError`**, so:
- Tools/agents get the same typed-error contract as every other failure.
- Any existing `except SarvamAPIError` handler keeps catching network failures (fully backward-compatible).
- The originating httpx exception is preserved via `raise ... from exc` for debugging.
- `status_code` is `None` since no HTTP response was ever received.

## Tests

Added two regression tests (and exported `SarvamConnectionError` from `sarvam_mcp.http`):

```
tests/test_client.py::test_auth_header_is_attached PASSED                [ 11%]
tests/test_client.py::test_401_maps_to_auth_error PASSED                 [ 22%]
tests/test_client.py::test_429_maps_to_rate_limit_with_retry_after PASSED [ 33%]
tests/test_client.py::test_400_maps_to_bad_request PASSED               [ 44%]
tests/test_client.py::test_5xx_retries_then_succeeds PASSED             [ 55%]
tests/test_client.py::test_5xx_exhausts_retries PASSED                  [ 66%]
tests/test_client.py::test_transport_error_maps_to_connection_error PASSED [ 77%]
tests/test_client.py::test_connection_error_is_a_sarvam_api_error PASSED [ 88%]
tests/test_client.py::test_binary_response_returned_as_bytes PASSED     [100%]

9 passed
```

The new tests assert: a transport failure raises `SarvamConnectionError` (not raw httpx), it retries 3× first, `status_code is None`, the httpx cause is chained, and it's catchable as `SarvamAPIError`.

## Scope / risk

- Touches only `src/sarvam_mcp/http/` (`client.py`, `errors.py`, `__init__.py`) and `tests/test_client.py`.
- No behavior change on the success path or on HTTP-status error paths; only the previously-unhandled transport-failure path changes (raw httpx → typed error).
- Backward-compatible: new error type subclasses the existing base.

## Open question for maintainers

I introduced a dedicated `SarvamConnectionError` to mirror the existing typed hierarchy (`SarvamAuthError` / `SarvamRateLimitError` / `SarvamBadRequestError`). If you'd prefer to keep the surface smaller and just raise the base `SarvamAPIError` for transport failures, happy to adjust — the catch/wrap location stays the same either way.