### PR TITLE
fix(analytics): redact API keys and secrets before sending telemetry

### DIFF
--- a/src/sarvam_mcp/analytics.py
+++ b/src/sarvam_mcp/analytics.py
@@ -25,6 +25,45 @@ _TRACK_URL = f"{_ANALYTICS_BASE.rstrip('/')}/api/track"
 
 _TIMEOUT = httpx.Timeout(2.0, connect=1.0)
 
+# Argument/field names whose values are secret and must never be sent to the
+# analytics endpoint. Matched case-insensitively against exact key names, so
+# benign keys like ``max_tokens`` are unaffected.
+_SENSITIVE_KEYS = frozenset(
+    {
+        "api_key",
+        "apikey",
+        "api-subscription-key",
+        "x-api-key",
+        "authorization",
+        "password",
+        "secret",
+        "token",
+        "access_token",
+        "refresh_token",
+        "auth_token",
+        "client_secret",
+    }
+)
+_REDACTED = "***redacted***"
+
+
+def _redact(obj: Any) -> Any:
+    """Recursively mask values of sensitive keys.
+
+    The analytics ping echoes back tool arguments/responses; without this,
+    calling ``sarvam_tools_set_api_key`` would transmit the user's API key to
+    the analytics endpoint. Masks by key name so the payload structure is
+    preserved for debugging.
+    """
+    if isinstance(obj, dict):
+        return {
+            k: (_REDACTED if isinstance(k, str) and k.lower() in _SENSITIVE_KEYS else _redact(v))
+            for k, v in obj.items()
+        }
+    if isinstance(obj, (list, tuple)):
+        return [_redact(v) for v in obj]
+    return obj
+
 
 def _get_install_id() -> str:
     """Return a stable anonymous install id, persisted in ~/.sarvam/install_id."""
@@ -73,9 +112,9 @@ async def _send(
             "install_id": _ensure_install_id(),
         }
         if arguments is not None:
-            payload["arguments"] = _safe_serialize(arguments)
+            payload["arguments"] = _safe_serialize(_redact(arguments))
         if response is not None:
-            payload["response"] = _safe_serialize(response)
+            payload["response"] = _safe_serialize(_redact(response))
 
         async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
             await client.post(_TRACK_URL, json=payload)

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,54 @@
+"""Analytics redaction — secrets must never reach the analytics endpoint."""
+
+from __future__ import annotations
+
+import sarvam_mcp.analytics as analytics
+from sarvam_mcp.analytics import _redact, _send
+
+
+def test_redact_masks_api_key():
+    out = _redact({"api_key": "sk_live_secret", "text": "hello"})
+    assert out == {"api_key": "***redacted***", "text": "hello"}
+
+
+def test_redact_is_case_insensitive_and_nested():
+    out = _redact(
+        {
+            "API_KEY": "sk_1",
+            "nested": {"Authorization": "Bearer xyz", "keep": 1},
+            "items": [{"token": "t"}, {"ok": True}],
+        }
+    )
+    assert out["API_KEY"] == "***redacted***"
+    assert out["nested"]["Authorization"] == "***redacted***"
+    assert out["nested"]["keep"] == 1
+    assert out["items"][0]["token"] == "***redacted***"
+    assert out["items"][1]["ok"] is True
+
+
+def test_redact_preserves_benign_keys():
+    # `max_tokens` contains the substring "token" but is not a secret — exact
+    # key matching must leave it untouched.
+    payload = {"max_tokens": 600, "model": "sarvam-30b", "temperature": 0.7}
+    assert _redact(payload) == payload
+
+
+async def test_send_does_not_transmit_api_key(httpx_mock, monkeypatch):
+    monkeypatch.setattr(analytics, "_install_id", "test-install-id")
+    httpx_mock.add_response(
+        method="POST",
+        url="https://mcp.sarvam.ai/api/track",
+        json={"ok": True},
+    )
+
+    await _send(
+        "sarvam_tools_set_api_key",
+        "ok",
+        "0.2.4",
+        {"api_key": "sk_live_SECRET_should_never_leave"},
+        {"status": "saved"},
+    )
+
+    body = httpx_mock.get_request().content.decode()
+    assert "sk_live_SECRET_should_never_leave" not in body
+    assert "***redacted***" in body


### PR DESCRIPTION
## Summary

The analytics middleware records **every** tool call by serializing its raw `arguments` (and `response`) and POSTing them to the analytics endpoint. For `sarvam_tools_set_api_key`, the arguments are `{"api_key": "sk_..."}` — so **the user's secret API key is transmitted in plaintext** to `https://mcp.sarvam.ai/api/track`.

The endpoint is also overridable via the `SARVAM_MCP_ANALYTICS_URL` env var, which turns this into a genuine credential-exfiltration vector (point it anywhere and every `set_api_key` call ships the key there).

## Root cause

```python
# src/sarvam_mcp/analytics.py — _send()
if arguments is not None:
    payload["arguments"] = _safe_serialize(arguments)   # ❌ raw args, incl. api_key
if response is not None:
    payload["response"] = _safe_serialize(response)
```

`_AnalyticsMiddleware.on_call_tool` (server.py) passes `context.message.arguments` straight through to `track_tool_use` → `_send` with no redaction.

## Reproduction

Driving the **real** middleware with a `set_api_key` call and capturing the outgoing analytics POST:

```python
class FakeMsg:
    name = "sarvam_tools_set_api_key"
    arguments = {"api_key": "sk_live_SECRET"}

await _AnalyticsMiddleware().on_call_tool(FakeCtx(), call_next)
# ... drain the fire-and-forget task ...
body = captured_request.content.decode()
assert "sk_live_SECRET" in body   # ← passes today: the key is in the telemetry body
```

## Fix

Add a recursive `_redact()` pass that masks values of known-sensitive keys before serialization, applied to **both** `arguments` and `response`:

```python
_SENSITIVE_KEYS = frozenset({
    "api_key", "apikey", "api-subscription-key", "x-api-key", "authorization",
    "password", "secret", "token", "access_token", "refresh_token",
    "auth_token", "client_secret",
})

def _redact(obj):
    if isinstance(obj, dict):
        return {k: ("***redacted***" if isinstance(k, str) and k.lower() in _SENSITIVE_KEYS
                    else _redact(v)) for k, v in obj.items()}
    if isinstance(obj, (list, tuple)):
        return [_redact(v) for v in obj]
    return obj
```

- Matches by **exact key name, case-insensitively**, so benign fields like `max_tokens` (which merely *contains* "token") are left untouched.
- Recurses into nested dicts/lists.
- Preserves payload structure (masked value, not dropped key) so analytics stays useful for debugging.

## Tests

New `tests/test_analytics.py` (all passing):

```
tests/test_analytics.py::test_redact_masks_api_key PASSED                [ 25%]
tests/test_analytics.py::test_redact_is_case_insensitive_and_nested PASSED [ 50%]
tests/test_analytics.py::test_redact_preserves_benign_keys PASSED        [ 75%]
tests/test_analytics.py::test_send_does_not_transmit_api_key PASSED      [100%]

4 passed
```

`test_send_does_not_transmit_api_key` drives `_send()` and asserts the secret is **absent** from the outgoing request body and `***redacted***` is present. `test_redact_preserves_benign_keys` guards against over-redacting `max_tokens`/`model`/etc.

## Scope / risk

- Touches only `src/sarvam_mcp/analytics.py` and adds `tests/test_analytics.py`.
- No change to analytics behavior other than masking sensitive values; non-sensitive telemetry is unchanged.
- `ruff` and `mypy` clean on the changed file.