### PR TITLE
fix(code): drop API-key requirement from build-time sarvam_code_* tools

### DIFF
--- a/src/sarvam_mcp/code/docs.py
+++ b/src/sarvam_mcp/code/docs.py
@@ -16,9 +16,7 @@ from typing import Any, Literal
 from fastmcp import Context, FastMCP
 from pydantic import Field
 
-from sarvam_mcp.auth.elicit import ensure_auth
 from sarvam_mcp.code import _data
-
 
 # ---- Type literals -------------------------------------------------------
 
@@ -57,7 +55,6 @@ def register(mcp: FastMCP) -> None:
         ctx: Context,
         endpoint: EndpointPath = Field(description="The Sarvam API path, e.g. '/text-to-speech'."),
     ) -> dict[str, Any]:
-        await ensure_auth(ctx)
         ref = _data.API_REFERENCE.get(endpoint)
         if not ref:
             return {
@@ -84,7 +81,6 @@ def register(mcp: FastMCP) -> None:
         ctx: Context,
         api: ApiName = Field(description="Which Sarvam API. STT covers 23; TTS covers 11."),
     ) -> dict[str, Any]:
-        await ensure_auth(ctx)
         langs = _data.LANGUAGES_BY_API.get(api, [])
         return {
             "api": api,
@@ -104,7 +100,6 @@ def register(mcp: FastMCP) -> None:
         ctx: Context,
         model: TtsModel = Field(default="bulbul:v3"),
     ) -> dict[str, Any]:
-        await ensure_auth(ctx)
         ids = _data.SPEAKERS_BY_MODEL.get(model, [])
         return {
             "model": model,
@@ -132,7 +127,6 @@ def register(mcp: FastMCP) -> None:
             description="Specific model id, e.g. 'bulbul:v3'. Omit to list all.",
         ),
     ) -> dict[str, Any]:
-        await ensure_auth(ctx)
         if model:
             entry = _data.PRICING.get(model)
             if not entry:

--- a/src/sarvam_mcp/code/snippets.py
+++ b/src/sarvam_mcp/code/snippets.py
@@ -10,7 +10,6 @@ from typing import Any, Literal
 from fastmcp import Context, FastMCP
 from pydantic import Field
 
-from sarvam_mcp.auth.elicit import ensure_auth
 from sarvam_mcp.code import _data
 from sarvam_mcp.code._snippets import SNIPPETS
 
@@ -38,7 +37,6 @@ def register(mcp: FastMCP) -> None:
             description="Programming language for the snippet.",
         ),
     ) -> dict[str, Any]:
-        await ensure_auth(ctx)
         snippet = SNIPPETS.get((api, language))
         if not snippet:
             return {
@@ -75,7 +73,6 @@ def register(mcp: FastMCP) -> None:
             description="What the dev wants to build, e.g. 'transcribe Hindi voicemails'.",
         ),
     ) -> dict[str, Any]:
-        await ensure_auth(ctx)
         return _recommend(task_description)
 
     @mcp.tool(
@@ -105,7 +102,6 @@ def register(mcp: FastMCP) -> None:
             description="The draft request body the agent is about to send.",
         ),
     ) -> dict[str, Any]:
-        await ensure_auth(ctx)
         issues = _validate(endpoint, body)
         return {
             "endpoint": endpoint,

--- a/tests/code/test_build_tools_no_auth.py
+++ b/tests/code/test_build_tools_no_auth.py
@@ -1,0 +1,54 @@
+"""Build-time `sarvam_code_*` tools must work without an API key.
+
+They return static reference data / snippets / heuristics and never call the
+Sarvam API, so requiring auth contradicts their documented contract
+(`code/__init__.py`, AGENTS.md, and the recommend_model description which
+states it "works without an API key").
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client, FastMCP
+
+import sarvam_mcp.auth.elicit as elicit
+from sarvam_mcp.auth.context import _current
+from sarvam_mcp.code import docs, snippets
+
+# (tool_name, arguments) for every build-time tool.
+BUILD_TOOLS = [
+    ("sarvam_code_snippet", {"api": "tts", "language": "python"}),
+    ("sarvam_code_recommend_model", {"task_description": "transcribe Hindi audio"}),
+    (
+        "sarvam_code_validate_request",
+        {"endpoint": "/text-to-speech", "body": {"inputs": ["hi"], "target_language_code": "hi-IN"}},
+    ),
+    ("sarvam_code_api_reference", {"endpoint": "/text-to-speech"}),
+    ("sarvam_code_languages", {"api": "tts"}),
+    ("sarvam_code_speakers", {"model": "bulbul:v3"}),
+    ("sarvam_code_pricing", {}),
+]
+
+
+@pytest.fixture
+def no_auth(monkeypatch, tmp_path):
+    """Simulate a fresh user: no provider, no env key, no credentials file."""
+    _current.set(None)
+    monkeypatch.delenv("SARVAM_API_KEY", raising=False)
+    monkeypatch.setattr(elicit, "CREDENTIALS_PATH", tmp_path / "missing" / "credentials")
+
+
+@pytest.fixture
+def code_server():
+    mcp = FastMCP("test")
+    snippets.register(mcp)
+    docs.register(mcp)
+    return mcp
+
+
+@pytest.mark.parametrize("tool_name,arguments", BUILD_TOOLS)
+async def test_build_tool_works_without_api_key(code_server, no_auth, tool_name, arguments):
+    async with Client(code_server) as client:
+        result = await client.call_tool(tool_name, arguments)
+    # No exception == no auth gate. Sanity-check it returned structured data.
+    assert result.structured_content is not None


### PR DESCRIPTION
## Summary

The `sarvam_code_*` tools are **build-time** helpers — they return static reference data, code snippets, and heuristic model recommendations, and **never call the Sarvam API**. But every one of them starts with `await ensure_auth(ctx)`, which raises a `ToolError` when no API key is configured.

This directly contradicts their documented contract:

- `code/__init__.py`: *"builder tools that help devs CREATE Sarvam-using apps … They do NOT call the Sarvam API at runtime."*
- `AGENTS.md`: *"These tools return documentation, code snippets, API reference, and project templates. They do NOT call the Sarvam API at runtime."*
- `sarvam_code_recommend_model`'s own description: *"Uses heuristics (no LLM call), so it's fast and **works without an API key**."*

So a developer evaluating Sarvam — who hasn't set up a key yet — is blocked from even getting a code snippet or a model recommendation, which is exactly the moment these tools are meant to help.

## Reproduction

Driving the registered tools with no provider / no env key / no credentials file:

```
sarvam_code_recommend_model → BLOCKED (ToolError: No API key found…)
sarvam_code_languages       → BLOCKED (ToolError: No API key found…)
sarvam_code_snippet         → BLOCKED (ToolError: No API key found…)
```

The existing `tests/code/` suite doesn't catch this because it tests the inner `_recommend` / `_validate` pure functions directly, bypassing the tool wrappers where `ensure_auth` lives.

## Fix

Remove the `await ensure_auth(ctx)` gate (and the now-unused import) from all **seven** build-time tools:

- `snippets.py`: `sarvam_code_snippet`, `sarvam_code_recommend_model`, `sarvam_code_validate_request`
- `docs.py`: `sarvam_code_api_reference`, `sarvam_code_languages`, `sarvam_code_speakers`, `sarvam_code_pricing`

These tools read only from the static `_data` tables / `SNIPPETS` dict, so there is nothing to authenticate. Runtime `sarvam_tools_*` tools are unaffected — they still go through `ready_ctx`/`ensure_auth` as before.

This is also strictly backward-compatible: users **with** a key could already call these tools; now users **without** a key can too.

## Tests

New `tests/code/test_build_tools_no_auth.py` — parametrized over all seven tools, drives each through an in-memory FastMCP client with **no key configured**, and asserts it returns structured data instead of raising:

```
tests/code/test_build_tools_no_auth.py::...[sarvam_code_snippet] PASSED
tests/code/test_build_tools_no_auth.py::...[sarvam_code_recommend_model] PASSED
tests/code/test_build_tools_no_auth.py::...[sarvam_code_validate_request] PASSED
tests/code/test_build_tools_no_auth.py::...[sarvam_code_api_reference] PASSED
tests/code/test_build_tools_no_auth.py::...[sarvam_code_languages] PASSED
tests/code/test_build_tools_no_auth.py::...[sarvam_code_speakers] PASSED
tests/code/test_build_tools_no_auth.py::...[sarvam_code_pricing] PASSED

7 passed
```

## Scope / risk

- Touches only `src/sarvam_mcp/code/{snippets,docs}.py` (removed lines) and adds one test file.
- No change to runtime tools or to what the build-time tools return.
- `ruff` and `mypy` clean on the changed files.