### PR TITLE
fix: remove ensure_auth from static sarvam_code_* tools

### DIFF
--- a/src/sarvam_mcp/code/docs.py
+++ b/src/sarvam_mcp/code/docs.py
@@ -13,12 +13,10 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from fastmcp import Context, FastMCP
+from fastmcp import FastMCP
 from pydantic import Field
 
-from sarvam_mcp.auth.elicit import ensure_auth
 from sarvam_mcp.code import _data
-
 
 # ---- Type literals -------------------------------------------------------
 
@@ -54,10 +52,8 @@ def register(mcp: FastMCP) -> None:
         ),
     )
     async def sarvam_code_api_reference(
-        ctx: Context,
         endpoint: EndpointPath = Field(description="The Sarvam API path, e.g. '/text-to-speech'."),
     ) -> dict[str, Any]:
-        await ensure_auth(ctx)
         ref = _data.API_REFERENCE.get(endpoint)
         if not ref:
             return {
@@ -81,10 +77,8 @@ def register(mcp: FastMCP) -> None:
         ),
     )
     async def sarvam_code_languages(
-        ctx: Context,
         api: ApiName = Field(description="Which Sarvam API. STT covers 23; TTS covers 11."),
     ) -> dict[str, Any]:
-        await ensure_auth(ctx)
         langs = _data.LANGUAGES_BY_API.get(api, [])
         return {
             "api": api,
@@ -101,10 +95,8 @@ def register(mcp: FastMCP) -> None:
         ),
     )
     async def sarvam_code_speakers(
-        ctx: Context,
         model: TtsModel = Field(default="bulbul:v3"),
     ) -> dict[str, Any]:
-        await ensure_auth(ctx)
         ids = _data.SPEAKERS_BY_MODEL.get(model, [])
         return {
             "model": model,
@@ -126,13 +118,11 @@ def register(mcp: FastMCP) -> None:
         ),
     )
     async def sarvam_code_pricing(
-        ctx: Context,
         model: str | None = Field(
             default=None,
             description="Specific model id, e.g. 'bulbul:v3'. Omit to list all.",
         ),
     ) -> dict[str, Any]:
-        await ensure_auth(ctx)
         if model:
             entry = _data.PRICING.get(model)
             if not entry:

--- a/src/sarvam_mcp/code/snippets.py
+++ b/src/sarvam_mcp/code/snippets.py
@@ -7,10 +7,9 @@ from __future__ import annotations
 import re
 from typing import Any, Literal
 
-from fastmcp import Context, FastMCP
+from fastmcp import FastMCP
 from pydantic import Field
 
-from sarvam_mcp.auth.elicit import ensure_auth
 from sarvam_mcp.code import _data
 from sarvam_mcp.code._snippets import SNIPPETS
 
@@ -31,14 +30,12 @@ def register(mcp: FastMCP) -> None:
         ),
     )
     async def sarvam_code_snippet(
-        ctx: Context,
         api: SnippetApi = Field(description="Which Sarvam API."),
         language: SnippetLanguage = Field(
             default="python",
             description="Programming language for the snippet.",
         ),
     ) -> dict[str, Any]:
-        await ensure_auth(ctx)
         snippet = SNIPPETS.get((api, language))
         if not snippet:
             return {
@@ -70,12 +67,10 @@ def register(mcp: FastMCP) -> None:
         ),
     )
     async def sarvam_code_recommend_model(
-        ctx: Context,
         task_description: str = Field(
             description="What the dev wants to build, e.g. 'transcribe Hindi voicemails'.",
         ),
     ) -> dict[str, Any]:
-        await ensure_auth(ctx)
         return _recommend(task_description)
 
     @mcp.tool(
@@ -90,7 +85,6 @@ def register(mcp: FastMCP) -> None:
         ),
     )
     async def sarvam_code_validate_request(
-        ctx: Context,
         endpoint: Literal[
             "/text-to-speech",
             "/speech-to-text",
@@ -105,7 +99,6 @@ def register(mcp: FastMCP) -> None:
             description="The draft request body the agent is about to send.",
         ),
     ) -> dict[str, Any]:
-        await ensure_auth(ctx)
         issues = _validate(endpoint, body)
         return {
             "endpoint": endpoint,


### PR DESCRIPTION
Problem

The sarvam_code_* builder tools (sarvam_code_languages, sarvam_code_speakers, sarvam_code_api_reference, sarvam_code_pricing, sarvam_code_snippet, sarvam_code_recommend_model, sarvam_code_validate_request) all called await ensure_auth(ctx) at the start of every function — even though they only return hard-coded local data and never make a single HTTP call to the Sarvam API.
This meant a brand-new user asking something as basic as "how do I call TTS?" or "which language codes does STT support?" would get blocked by an auth error before they could even learn how to set up their API key. sarvam_code_recommend_model even explicitly says in its description "works without an API key" — but the implementation contradicted that.
Fix
Removed await ensure_auth(ctx) and the now-unused ctx: Context parameter from all 7 static builder tools in src/sarvam_mcp/code/docs.py and src/sarvam_mcp/code/snippets.py. Also cleaned up the resulting unused imports (Context, ensure_auth) flagged by ruff.
Runtime tools (sarvam_tools_*) are completely untouched — ensure_auth remains in place everywhere an actual Sarvam API call is made.
Files changed

src/sarvam_mcp/code/docs.py
src/sarvam_mcp/code/snippets.py

Test results

46 passing ✅
2 pre-existing failures in tests/test_config.py on Windows (HOME vs USERPROFILE path resolution) — present on main before this change, unrelated to this PR