### PR TITLE
fix(build): add icon support — bundle icon.svg in package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ Repository = "https://github.com/sarvamai/sarvam-mcp"
 Issues = "https://github.com/sarvamai/sarvam-mcp/issues"
 Changelog = "https://github.com/sarvamai/sarvam-mcp/releases"
 
+[tool.hatch.build]
+artifacts = ["src/sarvam_mcp/icon.svg"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/sarvam_mcp"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sarvam-mcp"
-version = "0.2.7"
+version = "0.2.8"
 description = "Official Sarvam AI MCP server — STT, TTS, Translate, Transliterate, LLM, Vision OCR for Indic languages"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Hatchling excludes non-Python files by default, so `icon.svg` was silently dropped from wheel/sdist builds. This adds `artifacts = ["src/sarvam_mcp/icon.svg"]` so the MCP server icon renders in clients that support it.