### PR TITLE
fix(llm): raise a clear error on non-JSON chat responses

### DIFF
--- a/src/sarvam_mcp/tools/llm.py
+++ b/src/sarvam_mcp/tools/llm.py
@@ -63,6 +63,16 @@ def register(mcp: FastMCP) -> None:
             payload, call = await sc.client.post_json(CHAT_PATH, json_body=body)
             metrics.merge(call)
 
+        # stream=True makes the endpoint return text/event-stream, which the
+        # client surfaces as raw bytes. Fail clearly instead of crashing with
+        # "'bytes' object has no attribute 'get'".
+        if not isinstance(payload, dict):
+            raise RuntimeError(
+                f"Chat endpoint returned a non-JSON response ({type(payload).__name__}). "
+                "This tool returns a single completion and does not support streamed "
+                "responses — set stream=false (the default)."
+            )
+
         choice = (payload.get("choices") or [{}])[0]
         message = choice.get("message") or {}
         finish_reason = choice.get("finish_reason")

--- a/tests/tools/test_llm.py
+++ b/tests/tools/test_llm.py
@@ -1,0 +1,83 @@
+"""sarvam_tools_llm_complete — response handling."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from sarvam_mcp._registry import ServerContext
+from sarvam_mcp.audio import build_sink
+from sarvam_mcp.config import Config
+from sarvam_mcp.http import SarvamClient
+from sarvam_mcp.tools import llm
+
+CHAT_URL = "https://api.sarvam.ai/v1/chat/completions"
+
+
+@asynccontextmanager
+async def _client_for(tmp_path):
+    cfg = Config(
+        api_key="sk_x",
+        base_url="https://api.sarvam.ai",
+        base_path=tmp_path,
+        output_mode="files",
+    )
+    sc = ServerContext(
+        config=cfg,
+        client=SarvamClient(cfg.base_url),
+        audio_sink=build_sink("files", tmp_path),
+    )
+
+    @asynccontextmanager
+    async def lifespan(_s):
+        yield sc
+
+    mcp = FastMCP("test", lifespan=lifespan)
+    llm.register(mcp)
+    try:
+        async with Client(mcp) as client:
+            yield client
+    finally:
+        await sc.client.aclose()
+
+
+async def test_stream_true_raises_clear_error(httpx_mock, tmp_path):
+    # Per the Sarvam docs, stream=True returns server-sent events
+    # (text/event-stream), which the client surfaces as raw bytes.
+    httpx_mock.add_response(
+        method="POST",
+        url=CHAT_URL,
+        status_code=200,
+        content=b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n\n',
+        headers={"content-type": "text/event-stream"},
+    )
+    async with _client_for(tmp_path) as client:
+        with pytest.raises(Exception) as exc_info:
+            await client.call_tool(
+                "sarvam_tools_llm_complete",
+                {"messages": [{"role": "user", "content": "hi"}], "stream": True},
+            )
+    msg = str(exc_info.value)
+    assert "stream=false" in msg
+    # Not the opaque AttributeError that leaked before the fix.
+    assert "has no attribute" not in msg
+
+
+async def test_json_response_returns_content(httpx_mock, tmp_path):
+    httpx_mock.add_response(
+        method="POST",
+        url=CHAT_URL,
+        status_code=200,
+        json={
+            "choices": [{"message": {"role": "assistant", "content": "नमस्ते"}, "finish_reason": "stop"}],
+            "model": "sarvam-30b",
+        },
+    )
+    async with _client_for(tmp_path) as client:
+        result = await client.call_tool(
+            "sarvam_tools_llm_complete",
+            {"messages": [{"role": "user", "content": "hi"}]},
+        )
+    assert result.structured_content["content"] == "नमस्ते"


### PR DESCRIPTION
## Summary

`sarvam_tools_llm_complete` exposes a `stream` parameter. Per the [Sarvam docs](https://docs.sarvam.ai/api-reference-docs/chat/chat-completions), setting `stream=true` makes `/v1/chat/completions` return **server-sent events** (`text/event-stream`):

> "If set to true, the model response data will be streamed to the client as it is generated using server-sent events."

`SarvamClient` returns any non-JSON 200 body as raw **bytes**, and the tool then calls `.get("choices")` on those bytes — crashing with an opaque `'bytes' object has no attribute 'get'` that leaks to the agent.

## Root cause

```python
# src/sarvam_mcp/tools/llm.py
payload, call = await sc.client.post_json(CHAT_PATH, json_body=body)  # bytes when stream=true
...
choice = (payload.get("choices") or [{}])[0]   # ❌ AttributeError on bytes
```

## Fix

Guard the response: if the payload isn't a dict, raise a clear, actionable error instead of the opaque `AttributeError`.

```python
if not isinstance(payload, dict):
    raise RuntimeError(
        f"Chat endpoint returned a non-JSON response ({type(payload).__name__}). "
        "This tool returns a single completion and does not support streamed "
        "responses — set stream=false (the default)."
    )
```

The happy path (a JSON object) is unchanged. This also covers any other non-JSON 200 from the endpoint.

## Tests

New `tests/tools/test_llm.py`:

- `test_stream_true_raises_clear_error` — mocks the `text/event-stream` response that `stream=true` produces and asserts the tool raises a clear error (mentions `stream=false`), **not** the opaque `'... has no attribute ...'`.
- `test_json_response_returns_content` — the normal JSON path still returns the assistant content.

```
tests/tools/test_llm.py::test_stream_true_raises_clear_error PASSED
tests/tools/test_llm.py::test_json_response_returns_content PASSED
2 passed
```

`ruff check` and `ruff format --check` are clean on the changed files; the server builds and the tool registers.

## Open question for maintainers

Streaming gives this tool no benefit — it returns a single complete response regardless — so an alternative to the guard would be to **drop the `stream` parameter entirely** (it can only cause harm here). Happy to go that route instead; the description already notes "Streaming via MCP isn't useful for chat." Kept the parameter for backward-compatibility in this PR.

## Scope / risk

- Touches only `src/sarvam_mcp/tools/llm.py` (guard) and adds `tests/tools/test_llm.py`.
- No change to the success path or to any other tool.