### PR TITLE
fix(code): correct batch-STT endpoint in reference data

### DIFF
--- a/src/sarvam_mcp/code/_data.py
+++ b/src/sarvam_mcp/code/_data.py
@@ -156,7 +156,7 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
         },
         "notes": (
             "Saaras v3 is the recommended model. It supports 5 output modes via the `mode` parameter. "
-            "For >30s audio, use /speech-to-text/job/init."
+            "For >30s audio, use the batch job API at /speech-to-text/job/v1."
         ),
     },
     "/speech-to-text-translate": {
@@ -175,22 +175,29 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
         },
         "notes": "DEPRECATED. Migrate to /speech-to-text with model=saaras:v3 and mode=translate.",
     },
-    "/speech-to-text/job/init": {
+    "/speech-to-text/job/v1": {
         "method": "POST",
         "model": "saaras:v3 (recommended)",
         "content_type": "application/json",
         "request_body": {
-            "model":           "str",
-            "with_timestamps": "bool",
-            "language_code":   "str (optional)",
+            "job_parameters": (
+                "object — {model, language_code (optional), mode, with_timestamps, "
+                "with_diarization, num_speakers (optional)}"
+            ),
         },
         "response": {
-            "job_id":                  "str",
-            "input_storage_path":      "str — Azure Blob SAS URL (PUT audio here)",
-            "output_storage_path":     "str — Azure Blob SAS URL (poll for results)",
-            "storage_container_type":  "str — 'Azure'",
+            "job_id":                 "str (UUID)",
+            "job_state":              "str",
+            "storage_container_type": "str",
         },
-        "notes": "Async batch flow: init -> upload to SAS -> poll /speech-to-text/job/status?job_id=...",
+        "notes": (
+            "Job-based async pipeline for audio >30s (up to 20 files / 2 hours per job): "
+            "create job → get upload URLs (POST /speech-to-text/job/v1/upload-files) → "
+            "PUT files to the presigned URLs → "
+            "start (POST /speech-to-text/job/v1/{job_id}/start) → "
+            "poll status (GET /speech-to-text/job/v1/{job_id}/status) → "
+            "download results (POST /speech-to-text/job/v1/download-files)."
+        ),
     },
     "/translate": {
         "method": "POST",

--- a/src/sarvam_mcp/code/docs.py
+++ b/src/sarvam_mcp/code/docs.py
@@ -27,7 +27,7 @@ ApiName = Literal[
 EndpointPath = Literal[
     "/speech-to-text",
     "/speech-to-text-translate",
-    "/speech-to-text/job/init",
+    "/speech-to-text/job/v1",
     "/text-to-speech",
     "/translate",
     "/transliterate",

--- a/src/sarvam_mcp/code/snippets.py
+++ b/src/sarvam_mcp/code/snippets.py
@@ -164,7 +164,7 @@ def _recommend(task: str) -> dict[str, Any]:
             snippet_key=("stt", "python"),
             extras={
                 "mode": "transcribe",
-                "tip_long_audio": "For audio >30s, use /speech-to-text/job/init for the async batch flow.",
+                "tip_long_audio": "For audio >30s, use /speech-to-text/job/v1 for the async batch flow.",
             },
         )
 

--- a/tests/code/test_data.py
+++ b/tests/code/test_data.py
@@ -3,6 +3,16 @@
 from __future__ import annotations
 
 from sarvam_mcp.code import _data
+from sarvam_mcp.tools.stt import STT_JOB_BASE
+
+
+def test_batch_stt_reference_matches_runtime_endpoint():
+    # The sarvam_code_* docs must point devs at the real batch-STT endpoint
+    # the runtime actually calls (/speech-to-text/job/v1), not the stale
+    # /speech-to-text/job/init that was documented before.
+    assert STT_JOB_BASE == "/speech-to-text/job/v1"
+    assert STT_JOB_BASE in _data.API_REFERENCE
+    assert "/speech-to-text/job/init" not in _data.API_REFERENCE
 
 
 def test_all_languages_have_required_fields():


### PR DESCRIPTION
## Summary

The `sarvam_code_*` builder tools (which exist to hand developers correct API info) pointed at **`/speech-to-text/job/init`** for the async batch-STT flow. That endpoint is stale/wrong.

Per the [Sarvam docs](https://docs.sarvam.ai/api-reference-docs/api-guides-tutorials/speech-to-text/batch-api):

> "When you call init job, use `POST /speech-to-text/job/v1`." … "after `job_state` is Completed, call `POST /speech-to-text/job/v1/download-files`."

The runtime tools already use the correct path — `tools/stt.py` has `STT_JOB_BASE = "/speech-to-text/job/v1"`, mirroring `tools/vision.py`'s `…/job/v1` job pattern. Only the developer-facing reference data was out of date, so a dev calling `sarvam_code_api_reference('/speech-to-text/job/init')` or following the `recommend` tip got a wrong endpoint and an outdated request/response shape (the old `input_storage_path`/`output_storage_path` pattern).

## Changes

- `code/_data.py` — `API_REFERENCE`: rename `/speech-to-text/job/init` → `/speech-to-text/job/v1` and rewrite the entry to the real **create → upload-files → start → status → download-files** flow; fix the STT note tip.
- `code/docs.py` — update the `EndpointPath` enum value.
- `code/snippets.py` — update the `recommend` long-audio tip.
- `tests/code/test_data.py` — new test tying `API_REFERENCE` to the runtime `STT_JOB_BASE` constant so docs and code can't silently drift again.

## Safety

Reference-data only. `_data`/`API_REFERENCE` is consumed **exclusively** by the build-time `sarvam_code_*` tools, which return documentation and make no API calls. No runtime tool imports it — the tools that actually call Sarvam use their own constants and are untouched. **No runtime/deployed behavior changes**; this only makes the reported docs match the real API.

## Tests

```
tests/code/test_data.py::test_batch_stt_reference_matches_runtime_endpoint PASSED
... (full code/test_data.py suite) 6 passed
```

`ruff check` is clean on the changed files. (`_data.py` is a hand-aligned reference table with a per-file ruff lint ignore in `pyproject.toml`; I matched its existing alignment style rather than reformatting it, to avoid unrelated churn.)