### PR TITLE
fix(docs): correct tool names in the README tools table

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,20 +81,20 @@ All defaults below reflect the latest non-deprecated models.
 
 | Tool | What it does | Default model |
 |---|---|---|
-| `sarvam_stt_transcribe` | Audio file → transcript (5 modes) | `saaras:v3` |
-| `sarvam_tts_speak` | Text → audio file | `bulbul:v3` |
-| `sarvam_tts_stream` | Text → streamed audio | `bulbul:v3` |
-| `sarvam_translate` | Cross-language text translate | `mayura:v1` |
-| `sarvam_transliterate` | Script conversion | — |
-| `sarvam_identify_language` | Language + script detect | — |
-| `sarvam_text_analytics` | Typed Q&A over text | — |
-| `sarvam_llm_complete` | Chat completions | `sarvam-30b` |
-| `sarvam_vision_extract` | Document Intelligence | Sarvam Vision |
-| `sarvam_vision_job_status` | Poll Document Intelligence job | — |
-| `sarvam_pronunciation_list` | List pronunciation dictionaries | — |
-| `sarvam_pronunciation_get` | Get a pronunciation dictionary | — |
-| `sarvam_pronunciation_create` | Create a pronunciation dictionary | — |
-| `sarvam_pronunciation_delete` | Delete a pronunciation dictionary | — |
+| `sarvam_tools_stt_transcribe` | Audio file → transcript (5 modes) | `saaras:v3` |
+| `sarvam_tools_tts_speak` | Text → audio file | `bulbul:v3` |
+| `sarvam_tools_tts_stream` | Text → streamed audio | `bulbul:v3` |
+| `sarvam_tools_translate` | Cross-language text translate | `mayura:v1` |
+| `sarvam_tools_transliterate` | Script conversion | — |
+| `sarvam_tools_identify_language` | Language + script detect | — |
+| `sarvam_tools_text_analytics` | Typed Q&A over text | — |
+| `sarvam_tools_llm_complete` | Chat completions | `sarvam-30b` |
+| `sarvam_tools_vision_extract` | Document Intelligence | Sarvam Vision |
+| `sarvam_tools_vision_job_status` | Poll Document Intelligence job | — |
+| `sarvam_tools_pronunciation_list` | List pronunciation dictionaries | — |
+| `sarvam_tools_pronunciation_get` | Get a pronunciation dictionary | — |
+| `sarvam_tools_pronunciation_create` | Create a pronunciation dictionary | — |
+| `sarvam_tools_pronunciation_delete` | Delete a pronunciation dictionary | — |
 
 ## Configuration
 

--- a/tests/test_readme_tools.py
+++ b/tests/test_readme_tools.py
@@ -1,0 +1,29 @@
+"""The tool names in the README Tools table must be real registered tools."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from sarvam_mcp.server import build_server
+
+README = Path(__file__).resolve().parent.parent / "README.md"
+
+
+def _readme_table_tool_names() -> list[str]:
+    text = README.read_text(encoding="utf-8")
+    # Scope to the "## Tools" section only (up to the next "## " heading).
+    section = text.split("## Tools", 1)[1].split("\n## ", 1)[0]
+    # Each table row's first column is a backticked tool name.
+    return re.findall(r"^\|\s*`(sarvam_[a-z_]+)`", section, re.MULTILINE)
+
+
+async def test_readme_tool_names_are_registered():
+    server = build_server()
+    registered = {t.name for t in await server.list_tools()}
+
+    names = _readme_table_tool_names()
+    assert names, "no tool names parsed from the README Tools table"
+
+    unregistered = [n for n in names if n not in registered]
+    assert not unregistered, f"README lists tool names that aren't registered: {unregistered}"


### PR DESCRIPTION
## Summary

The **Tools** table in the README lists every runtime tool **without the `sarvam_tools_` prefix** — e.g. it says `sarvam_stt_transcribe`, but the registered tool name is `sarvam_tools_stt_transcribe`. All 14 listed names are affected.

This also contradicts the README's own **"Two namespaces"** section, which correctly states runtime tools are `sarvam_tools_*`. An agent or user copying a name straight from the table would call a tool that doesn't exist.

## Verification (authoritative source = registered names)

Parsing the README Tools table and checking each name against `build_server().list_tools()`:

```
PRE-FIX: 14 names in the table are not registered tools:
  sarvam_stt_transcribe, sarvam_tts_speak, sarvam_tts_stream, sarvam_translate,
  sarvam_transliterate, sarvam_identify_language, sarvam_text_analytics,
  sarvam_llm_complete, sarvam_vision_extract, sarvam_vision_job_status,
  sarvam_pronunciation_list/get/create/delete
POST-FIX: all 14 match a registered tool.
```

## Changes

- `README.md` — prefix all 14 Tools-table entries with `sarvam_tools_` so they match the registered names (and the README's own namespace section).
- `tests/test_readme_tools.py` — new test that parses the README Tools table and asserts every listed name is actually registered on the server, so docs and code can't drift again.

## Safety

Docs + test only. No source/runtime code changed; zero behavior impact. Full suite passes (the only failures are the pre-existing Windows-only `tests/test_config.py` cases, which pass on the ubuntu CI). `ruff check` / `ruff format --check` clean on the new test file.