### PR TITLE
fix(stt): map "auto" auto-detect token to "unknown" for STT endpoints

### DIFF
--- a/src/sarvam_mcp/tools/stt.py
+++ b/src/sarvam_mcp/tools/stt.py
@@ -32,6 +32,17 @@ InputAudioCodec = Literal["pcm_s16le", "pcm_l16", "pcm_raw"]
 SaarasModel = Literal["saaras:v3", "saaras:v3-realtime", "saaras:v2.5"]
 
 
+def _stt_language_code(language_code: LanguageCode) -> LanguageCode:
+    """Map the shared auto-detect token to the value the STT API expects.
+
+    The shared ``LanguageCode`` enum carries two auto-detect tokens: ``"auto"``
+    (Translate/Transliterate) and ``"unknown"`` (STT). The STT endpoints only
+    accept ``"unknown"``, so normalize ``"auto"`` to it, mirroring how
+    ``translate``/``transliterate`` normalize ``"unknown"`` to ``"auto"``.
+    """
+    return "unknown" if language_code == "auto" else language_code
+
+
 def register(mcp: FastMCP) -> None:
     @mcp.tool(
         name="sarvam_tools_stt_transcribe",
@@ -104,7 +115,7 @@ def register(mcp: FastMCP) -> None:
                     files = {"file": (path.name, fh, _guess_audio_mime(path))}
                     data: dict[str, Any] = {
                         "model": model,
-                        "language_code": language_code,
+                        "language_code": _stt_language_code(language_code),
                         "with_timestamps": str(with_timestamps).lower(),
                     }
                     if model == "saaras:v3" and mode != "transcribe":
@@ -239,7 +250,9 @@ def register(mcp: FastMCP) -> None:
                 # Step 1: Create the job
                 await ctx.info("Creating batch STT job…")
                 job_params: dict[str, Any] = {
-                    "language_code": language_code if language_code != "unknown" else None,
+                    "language_code": (
+                        None if _stt_language_code(language_code) == "unknown" else language_code
+                    ),
                     "model": model,
                     "mode": mode,
                     "with_timestamps": with_timestamps,

--- a/tests/tools/test_stt_language_code.py
+++ b/tests/tools/test_stt_language_code.py
@@ -1,0 +1,78 @@
+"""STT language-code normalization.
+
+The shared ``LanguageCode`` enum carries two auto-detect tokens: ``"auto"``
+(accepted by Translate/Transliterate) and ``"unknown"`` (accepted by STT). The
+STT endpoints reject ``"auto"``, so the tools must map it to ``"unknown"`` the
+same way ``translate``/``transliterate`` map ``"unknown"`` to ``"auto"``.
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from sarvam_mcp._registry import ServerContext
+from sarvam_mcp.audio.sinks import FileSink
+from sarvam_mcp.config import Config
+from sarvam_mcp.http import SarvamClient
+from sarvam_mcp.server import build_server
+from sarvam_mcp.tools.stt import _stt_language_code
+
+# A minimal WAV header so file/MIME handling has something real to chew on.
+_WAV = b"RIFF\x24\x00\x00\x00WAVEfmt " + b"\x00" * 16
+
+
+def _fake_ctx(server_ctx: ServerContext) -> SimpleNamespace:
+    return SimpleNamespace(request_context=SimpleNamespace(lifespan_context=server_ctx))
+
+
+def _form_field(content: bytes, name: str) -> bytes | None:
+    m = re.search(rb'name="' + name.encode() + rb'"\r\n\r\n(.*?)\r\n', content, re.DOTALL)
+    return m.group(1) if m else None
+
+
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [("auto", "unknown"), ("unknown", "unknown"), ("hi-IN", "hi-IN")],
+)
+def test_stt_language_code_maps_auto_to_unknown(given: str, expected: str) -> None:
+    assert _stt_language_code(given) == expected  # type: ignore[arg-type]
+
+
+async def test_transcribe_sends_unknown_for_auto(httpx_mock, tmp_path: Path) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.sarvam.ai/speech-to-text",
+        json={"transcript": "ok", "language_code": "hi-IN"},
+    )
+
+    server = build_server()
+    server_ctx = ServerContext(
+        config=Config(),
+        client=SarvamClient("https://api.sarvam.ai"),
+        audio_sink=FileSink(tmp_path / "out"),
+    )
+    tool = await server.get_tool("sarvam_tools_stt_transcribe")
+
+    try:
+        await tool.fn(
+            ctx=_fake_ctx(server_ctx),
+            audio_path=None,
+            audio_base64=base64.b64encode(_WAV).decode(),
+            audio_url=None,
+            filename="clip.wav",
+            language_code="auto",
+            mode="transcribe",
+            with_timestamps=False,
+            model="saaras:v3",
+            input_audio_codec=None,
+        )
+    finally:
+        await server_ctx.client.aclose()
+
+    request = httpx_mock.get_request()
+    assert _form_field(request.content, "language_code") == b"unknown"


### PR DESCRIPTION
The STT tools take a `language_code` from the shared `LanguageCode` enum, which carries two auto-detect tokens: `"auto"` and `"unknown"`. The `/speech-to-text` endpoints only accept `"unknown"` for auto-detection ([docs](https://docs.sarvam.ai/api-reference-docs/speech-to-text/transcribe)), while translate/transliterate only accept `"auto"`.

#17 added the normalization on the translate/transliterate side (`"unknown"` to `"auto"`), but the STT side never got the mirror image. `sarvam_stt_transcribe` passed `language_code` straight through, and `sarvam_stt_batch_submit` only special-cased `"unknown"`. So calling either tool with `"auto"` sent a value the endpoint rejects instead of auto-detecting the language.

### Fix

Add a small `_stt_language_code` helper that maps `"auto"` to `"unknown"`, and use it in the transcribe and batch-submit request bodies.

### Tests

- A unit test for the helper: `"auto"` becomes `"unknown"`, and `"unknown"` / real codes pass through.
- An integration test that drives `sarvam_tools_stt_transcribe` with `language_code="auto"` and asserts the outbound request sends `language_code=unknown` (httpx mocked, no live API needed).

`pytest -q` is green (65 passed) and `ruff check` is clean.