### PR TITLE
feat(workflows): add sv_meet meeting transcription and summarisation

### DIFF
--- a/src/sarvam_mcp/server.py
+++ b/src/sarvam_mcp/server.py
@@ -134,6 +134,7 @@ def build_server() -> FastMCP:
     workflows.dub.register(mcp)
     workflows.localize.register(mcp)
     workflows.recall.register(mcp)
+    workflows.meet.register(mcp)
 
     return mcp
 

--- a/src/sarvam_mcp/workflows/__init__.py
+++ b/src/sarvam_mcp/workflows/__init__.py
@@ -9,6 +9,6 @@ the atomic tools so any naming clash falls in favor of the explicit
 ``sarvam_*`` ones.
 """
 
-from sarvam_mcp.workflows import dub, localize, recall, voice
+from sarvam_mcp.workflows import dub, localize, meet, recall, voice
 
-__all__ = ["dub", "localize", "recall", "voice"]
+__all__ = ["dub", "localize", "meet", "recall", "voice"]

--- a/src/sarvam_mcp/workflows/_helpers.py
+++ b/src/sarvam_mcp/workflows/_helpers.py
@@ -7,10 +7,13 @@ they exist to compose, not to reimplement.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import uuid
 from pathlib import Path
 from typing import Any
+
+import httpx
 
 from sarvam_mcp._registry import ServerContext
 from sarvam_mcp.audio import StoredAudio
@@ -143,3 +146,108 @@ async def llm_complete(
 def merge(metrics: ToolMetrics, call: CallMetrics) -> None:
     """Convenience re-export so workflow modules don't import observability directly."""
     metrics.merge(call)
+
+
+_BATCH_JOB_BASE = "/speech-to-text/job/v1"
+_BATCH_JOB_UPLOAD = f"{_BATCH_JOB_BASE}/upload-files"
+_BATCH_MAX_POLLS = 90
+_BATCH_POLL_INTERVAL = 2  # seconds
+
+
+async def stt_transcribe_diarized(
+    sc: ServerContext,
+    audio_path: Path,
+    *,
+    language_code: str = "unknown",
+    model: str = "saaras:v3",
+    num_speakers: int | None = None,
+    metrics: ToolMetrics | None = None,
+    ctx: Any = None,
+) -> tuple[str, list[dict[str, Any]], str | None]:
+    """Batch STT with diarization enabled.
+
+    Returns (flat_transcript, diarized_turns, detected_language_code).
+    ``diarized_turns`` is a list of per-speaker turn dicts from the API;
+    empty list when the API does not return diarization data.
+    """
+
+    async def _info(msg: str) -> None:
+        if ctx is not None:
+            await ctx.info(msg)
+
+    job_params: dict[str, Any] = {
+        "model": model,
+        "with_diarization": True,
+    }
+    if language_code != "unknown":
+        job_params["language_code"] = language_code
+    if num_speakers is not None:
+        job_params["num_speakers"] = num_speakers
+
+    await _info("Creating batch STT job…")
+    create_resp, call = await sc.client.post_json(_BATCH_JOB_BASE, json_body={"job_parameters": job_params})
+    if metrics is not None:
+        metrics.merge(call)
+    job_id = create_resp["job_id"]
+
+    await _info(f"Registering audio file for job {job_id}…")
+    upload_resp, call = await sc.client.post_json(
+        _BATCH_JOB_UPLOAD,
+        json_body={"job_id": job_id, "files": [audio_path.name]},
+    )
+    if metrics is not None:
+        metrics.merge(call)
+    upload_urls = upload_resp.get("upload_urls", {})
+    if not upload_urls:
+        raise RuntimeError(f"No upload URLs returned for job {job_id}")
+
+    await _info("Uploading audio to Azure Blob…")
+    file_details = next(iter(upload_urls.values()))
+    presigned_url = file_details["file_url"]
+    file_metadata = file_details.get("file_metadata") or {}
+    extra_headers = {str(k): str(v) for k, v in file_metadata.items()}
+    with audio_path.open("rb") as fh:
+        blob_call = await sc.client.put_blob(
+            presigned_url,
+            fh.read(),
+            content_type=_audio_mime(audio_path),
+            extra_headers=extra_headers,
+        )
+    if metrics is not None:
+        metrics.merge(blob_call)
+
+    await _info("Starting batch processing…")
+    _, call = await sc.client.post_json(
+        f"{_BATCH_JOB_BASE}/{job_id}/start",
+        json_body={"job_id": job_id, "job_parameters": job_params},
+    )
+    if metrics is not None:
+        metrics.merge(call)
+
+    await _info("Polling for completion…")
+    terminal = {"Completed", "PartiallyCompleted", "Failed", "failed", "error"}
+    status_resp: dict[str, Any] = {}
+    for _ in range(_BATCH_MAX_POLLS):
+        status_resp, call = await sc.client.get_json(f"{_BATCH_JOB_BASE}/{job_id}/status")
+        if metrics is not None:
+            metrics.merge(call)
+        if status_resp.get("job_state", "") in terminal:
+            break
+        await asyncio.sleep(_BATCH_POLL_INTERVAL)
+
+    result = status_resp.get("result") or {}
+    transcript = result.get("transcript") or status_resp.get("transcript") or ""
+    diarized: list[dict[str, Any]] = result.get("diarized_transcript") or []
+
+    if not transcript and status_resp.get("download_urls"):
+        dl_url = next(iter(status_resp["download_urls"].values()))["file_url"]
+        await _info("Downloading transcript…")
+        async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as dl:
+            dl_resp = await dl.get(dl_url)
+        if dl_resp.is_success:
+            dl_body = dl_resp.json()
+            transcript = dl_body.get("transcript", "")
+            diarized = dl_body.get("diarized_transcript") or []
+            result = dl_body
+
+    return transcript, diarized, result.get("language_code")

--- a/src/sarvam_mcp/workflows/meet.py
+++ b/src/sarvam_mcp/workflows/meet.py
@@ -1,0 +1,197 @@
+"""``sv_meet`` — meeting transcription, diarization, and summarisation.
+
+Pipeline: batch STT with diarization → speaker-labelled transcript →
+LLM structured summary (meeting overview, action items, decisions).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from fastmcp import Context, FastMCP
+from pydantic import Field
+
+from sarvam_mcp.observability import measure_tool
+from sarvam_mcp.tools._common import LanguageCode, SarvamLLM, ready_ctx, resolve_file_input
+from sarvam_mcp.workflows._helpers import llm_complete, stt_transcribe_diarized
+
+_SYSTEM_PROMPT = """\
+You are a meeting summariser. You will be given a speaker-labelled transcript of a meeting.
+Respond ONLY in the exact format below, with no additional text before or after.
+
+## Summary
+<2-4 sentence overview of what the meeting was about>
+
+## Action Items
+- <action item with owner if mentioned>
+- <next action item>
+
+## Decisions
+- <decision reached>
+- <next decision>
+
+If there are no action items or no decisions, write "None." as the sole item under that heading.\
+"""
+
+
+def register(mcp: FastMCP) -> None:
+    @mcp.tool(
+        name="sarvam_tools_meet",
+        description=(
+            "Runtime tool — calls Sarvam API now. For code-writing help, use sarvam_code_* tools.\n\n"
+            "Transcribe a meeting recording and produce a structured summary. "
+            "Pipeline: batch STT with speaker diarization → speaker-labelled transcript → "
+            "LLM extraction of summary, action items, and decisions. "
+            "Works with long audio files; supports all Indic languages."
+        ),
+    )
+    async def sv_meet(
+        ctx: Context,
+        audio_path: str | None = Field(default=None, description="Local path to the meeting audio file."),
+        audio_base64: str | None = Field(default=None, description="Base64-encoded audio data."),
+        audio_url: str | None = Field(default=None, description="URL to fetch the audio file from."),
+        filename: str | None = Field(default=None, description="Filename with extension (for base64/URL)."),
+        language_code: LanguageCode = Field(
+            default="unknown",
+            description="STT language hint. 'unknown' enables auto-detect.",
+        ),
+        num_speakers: int | None = Field(
+            default=None,
+            description="Expected number of speakers. Improves diarization accuracy when known.",
+            ge=2,
+            le=10,
+        ),
+        llm_model: SarvamLLM = Field(
+            default="sarvam-30b",
+            description="`sarvam-30b` (default) or `sarvam-105b` (flagship).",
+        ),
+    ) -> dict[str, Any]:
+        sc = await ready_ctx(ctx)
+        async with resolve_file_input(
+            file_path=audio_path,
+            file_base64=audio_base64,
+            file_url=audio_url,
+            filename=filename,
+        ) as path:
+            with measure_tool() as metrics:
+                await ctx.info("Transcribing meeting audio with diarization…")
+                flat_transcript, diarized_turns, detected_lang = await stt_transcribe_diarized(
+                    sc,
+                    path,
+                    language_code=language_code,
+                    num_speakers=num_speakers,
+                    metrics=metrics,
+                    ctx=ctx,
+                )
+
+                if not flat_transcript.strip() and not diarized_turns:
+                    raise RuntimeError("STT returned an empty transcript — nothing to summarise.")
+
+                labeled_transcript, normalized_turns = _render_transcript(diarized_turns, flat_transcript)
+
+                await ctx.info("Summarising meeting with LLM…")
+                raw_llm = await llm_complete(
+                    sc,
+                    [
+                        {"role": "system", "content": _SYSTEM_PROMPT},
+                        {"role": "user", "content": f"TRANSCRIPT:\n{labeled_transcript}"},
+                    ],
+                    model=llm_model,
+                    temperature=0.3,
+                    max_tokens=1200,
+                    metrics=metrics,
+                )
+
+        summary, action_items, decisions = _parse_llm_sections(raw_llm)
+
+        return {
+            "transcript": labeled_transcript,
+            "diarized_turns": normalized_turns,
+            "language_code": detected_lang,
+            "summary": summary,
+            "action_items": action_items,
+            "decisions": decisions,
+            "observability": metrics.to_response_block(),
+        }
+
+
+# ----- helpers ---------------------------------------------------------------
+
+
+def _render_transcript(
+    diarized_turns: list[dict[str, Any]],
+    flat_fallback: str,
+) -> tuple[str, list[dict[str, Any]]]:
+    """Build a labelled transcript string and normalised turn list.
+
+    Maps SPEAKER_00 → Speaker 1, SPEAKER_01 → Speaker 2, etc.
+    Falls back to the flat STT transcript when no diarized turns are available.
+    """
+    if not diarized_turns:
+        return flat_fallback, []
+
+    speaker_map: dict[str, str] = {}
+    normalized: list[dict[str, Any]] = []
+    lines: list[str] = []
+
+    for turn in diarized_turns:
+        raw_id = str(turn.get("speaker", "SPEAKER_00"))
+        if raw_id not in speaker_map:
+            speaker_map[raw_id] = f"Speaker {len(speaker_map) + 1}"
+        label = speaker_map[raw_id]
+        text = (turn.get("transcript") or turn.get("text") or "").strip()
+        normalized.append(
+            {
+                "speaker": label,
+                "text": text,
+                "start": turn.get("start"),
+                "end": turn.get("end"),
+            }
+        )
+        if text:
+            lines.append(f"{label}: {text}")
+
+    return "\n".join(lines), normalized
+
+
+def _parse_llm_sections(text: str) -> tuple[str, list[str], list[str]]:
+    """Split LLM output into (summary, action_items, decisions)."""
+    summary = ""
+    action_items: list[str] = []
+    decisions: list[str] = []
+
+    for section in re.split(r"^##\s+", text, flags=re.MULTILINE):
+        section = section.strip()
+        if not section:
+            continue
+        lines = section.splitlines()
+        header = lines[0].strip().lower()
+        body = "\n".join(lines[1:]).strip()
+
+        if "summary" in header:
+            summary = body
+        elif "action" in header:
+            action_items = _extract_bullets(body)
+        elif "decision" in header:
+            decisions = _extract_bullets(body)
+
+    return summary, action_items, decisions
+
+
+def _extract_bullets(text: str) -> list[str]:
+    """Parse bullet list lines into plain strings. Skips 'None.' placeholders."""
+    items: list[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith(("- ", "* ", "• ")):
+            content = line[2:].strip()
+        elif line[0].isdigit() and ". " in line:
+            content = line.split(". ", 1)[1].strip()
+        else:
+            continue
+        if content.lower() not in {"none.", "none"}:
+            items.append(content)
+    return items

--- a/tests/tools/test_meet.py
+++ b/tests/tools/test_meet.py
@@ -1,0 +1,226 @@
+"""Unit tests for the sv_meet workflow helpers and the diarized STT helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from sarvam_mcp.workflows.meet import _extract_bullets, _parse_llm_sections, _render_transcript
+
+# ---------------------------------------------------------------------------
+# _render_transcript
+# ---------------------------------------------------------------------------
+
+
+def test_render_transcript_maps_speaker_ids():
+    turns = [
+        {"speaker": "SPEAKER_00", "transcript": "Good morning everyone."},
+        {"speaker": "SPEAKER_01", "transcript": "Hi, let's get started."},
+        {"speaker": "SPEAKER_00", "transcript": "Sure, agenda first."},
+    ]
+    labeled, normalized = _render_transcript(turns, "")
+
+    assert labeled == (
+        "Speaker 1: Good morning everyone.\nSpeaker 2: Hi, let's get started.\nSpeaker 1: Sure, agenda first."
+    )
+    assert normalized[0]["speaker"] == "Speaker 1"
+    assert normalized[1]["speaker"] == "Speaker 2"
+    assert normalized[2]["speaker"] == "Speaker 1"
+
+
+def test_render_transcript_accepts_text_key():
+    turns = [{"speaker": "SPEAKER_00", "text": "Hello."}]
+    labeled, normalized = _render_transcript(turns, "")
+    assert "Speaker 1: Hello." in labeled
+    assert normalized[0]["text"] == "Hello."
+
+
+def test_render_transcript_falls_back_when_no_turns():
+    flat = "This is the flat transcript."
+    labeled, normalized = _render_transcript([], flat)
+    assert labeled == flat
+    assert normalized == []
+
+
+def test_render_transcript_skips_empty_text_turns():
+    turns = [
+        {"speaker": "SPEAKER_00", "transcript": ""},
+        {"speaker": "SPEAKER_01", "transcript": "Actually here."},
+    ]
+    labeled, _ = _render_transcript(turns, "")
+    assert "Speaker 1:" not in labeled
+    assert "Speaker 2: Actually here." in labeled
+
+
+# ---------------------------------------------------------------------------
+# _parse_llm_sections
+# ---------------------------------------------------------------------------
+
+
+_FULL_LLM_OUTPUT = """\
+## Summary
+The team discussed Q3 targets and the product roadmap.
+
+## Action Items
+- Alice to send the updated spec by Friday
+- Bob to schedule a follow-up with engineering
+
+## Decisions
+- Launch date moved to October 1
+- Budget approved for the new infra
+"""
+
+_NONE_LLM_OUTPUT = """\
+## Summary
+A quick sync to align on priorities.
+
+## Action Items
+- None.
+
+## Decisions
+- None.
+"""
+
+
+def test_parse_llm_sections_full():
+    summary, actions, decisions = _parse_llm_sections(_FULL_LLM_OUTPUT)
+    assert "Q3 targets" in summary
+    assert len(actions) == 2
+    assert actions[0] == "Alice to send the updated spec by Friday"
+    assert len(decisions) == 2
+    assert decisions[0] == "Launch date moved to October 1"
+
+
+def test_parse_llm_sections_none_placeholders():
+    summary, actions, decisions = _parse_llm_sections(_NONE_LLM_OUTPUT)
+    assert "quick sync" in summary
+    assert actions == []
+    assert decisions == []
+
+
+def test_parse_llm_sections_missing_sections():
+    # If the LLM omits sections entirely, return empty lists — not an error.
+    summary, actions, decisions = _parse_llm_sections("## Summary\nJust a summary.")
+    assert summary == "Just a summary."
+    assert actions == []
+    assert decisions == []
+
+
+# ---------------------------------------------------------------------------
+# _extract_bullets
+# ---------------------------------------------------------------------------
+
+
+def test_extract_bullets_handles_numbered_list():
+    text = "1. First item\n2. Second item"
+    assert _extract_bullets(text) == ["First item", "Second item"]
+
+
+def test_extract_bullets_handles_mixed_formats():
+    text = "- Dash item\n* Star item\n• Bullet item"
+    assert _extract_bullets(text) == ["Dash item", "Star item", "Bullet item"]
+
+
+# ---------------------------------------------------------------------------
+# stt_transcribe_diarized — integration with httpx_mock
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def server_ctx(tmp_path):
+    """Minimal ServerContext for workflow helper tests."""
+    from sarvam_mcp._registry import ServerContext
+    from sarvam_mcp.audio.sinks import FileSink
+    from sarvam_mcp.config import Config
+    from sarvam_mcp.http import SarvamClient
+
+    client = SarvamClient("https://api.sarvam.ai")
+    config = Config()
+    sink = FileSink(tmp_path / "out")
+    sc = ServerContext(config=config, client=client, audio_sink=sink)
+    yield sc
+    await client.aclose()
+
+
+async def test_stt_transcribe_diarized_happy_path(server_ctx, tmp_path, httpx_mock):
+    from sarvam_mcp.workflows._helpers import stt_transcribe_diarized
+
+    audio_file = tmp_path / "meeting.wav"
+    audio_file.write_bytes(b"RIFF" + b"\x00" * 40)
+
+    diarized_turns = [
+        {"speaker": "SPEAKER_00", "transcript": "Hello team.", "start": 0.0, "end": 2.0},
+        {"speaker": "SPEAKER_01", "transcript": "Hi everyone.", "start": 2.5, "end": 4.5},
+    ]
+
+    # 1. Create job
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.sarvam.ai/speech-to-text/job/v1",
+        json={"job_id": "job-abc"},
+    )
+    # 2. Register files
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.sarvam.ai/speech-to-text/job/v1/upload-files",
+        json={
+            "upload_urls": {
+                "meeting.wav": {
+                    "file_url": "https://blob.azure.example.com/upload?sas=token",
+                    "file_metadata": {},
+                }
+            }
+        },
+    )
+    # 3. Azure Blob PUT
+    httpx_mock.add_response(
+        method="PUT",
+        url="https://blob.azure.example.com/upload?sas=token",
+        status_code=201,
+    )
+    # 4. Start job
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.sarvam.ai/speech-to-text/job/v1/job-abc/start",
+        json={"job_id": "job-abc"},
+    )
+    # 5. Status — Completed
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.sarvam.ai/speech-to-text/job/v1/job-abc/status",
+        json={
+            "job_state": "Completed",
+            "result": {
+                "transcript": "Hello team. Hi everyone.",
+                "diarized_transcript": diarized_turns,
+                "language_code": "en-IN",
+            },
+        },
+    )
+
+    transcript, turns, lang = await stt_transcribe_diarized(server_ctx, audio_file)
+
+    assert transcript == "Hello team. Hi everyone."
+    assert lang == "en-IN"
+    assert len(turns) == 2
+    assert turns[0]["speaker"] == "SPEAKER_00"
+
+
+async def test_stt_transcribe_diarized_no_upload_urls_raises(server_ctx, tmp_path, httpx_mock):
+    from sarvam_mcp.workflows._helpers import stt_transcribe_diarized
+
+    audio_file = tmp_path / "meeting.wav"
+    audio_file.write_bytes(b"RIFF" + b"\x00" * 40)
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.sarvam.ai/speech-to-text/job/v1",
+        json={"job_id": "job-xyz"},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.sarvam.ai/speech-to-text/job/v1/upload-files",
+        json={"upload_urls": {}},
+    )
+
+    with pytest.raises(RuntimeError, match="No upload URLs"):
+        await stt_transcribe_diarized(server_ctx, audio_file)

--- a/tests/tools/test_registration.py
+++ b/tests/tools/test_registration.py
@@ -27,6 +27,7 @@ EXPECTED_TOOLS = {
     "sarvam_tools_dub",
     "sarvam_tools_localize",
     "sarvam_tools_recall",
+    "sarvam_tools_meet",
 }
 
 


### PR DESCRIPTION
Resolves #39

## Summary

Existing workflow do not handles the specific shape of a meeting recording: multi-speaker audio that needs a speaker-labelled transcript plus structured output (summary, action items, decisions) in one call. This PR adds `sarvam_tools_meet` (`sv_meet`) to fill that gap.

## Root cause

`workflows/_helpers.py` exposes `stt_transcribe()`, which wraps the simple `/speech-to-text` endpoint. That endpoint does not support diarization. The only path to diarized output today is the batch job flow — but that is buried inside the atomic `sarvam_tools_stt_batch_submit` tool and not reachable from any workflow:

```python
#  workflows/_helpers.py — stt_transcribe() cannot diarize
async def stt_transcribe(sc, audio_path, *, language_code="unknown", ...):
    files = {"file": (audio_path.name, fh, _audio_mime(audio_path))}
    data = {"model": model, "language_code": language_code, ...}
    body, call = await sc.client.post_multipart("/speech-to-text", data=data, files=files)
    return body.get("transcript", ""), body.get("language_code")
    #  no with_diarization param — endpoint does not support it
```

A user wanting meeting transcription today must manually chain five steps: create batch job → register file → PUT to Azure Blob → start job → poll status — then write their own LLM prompt. No workflow covers this.

## Fix

Added `stt_transcribe_diarized()` to `workflows/_helpers.py` implementing the full batch STT + diarization flow as a reusable helper, then composed it with `llm_complete()` in a new `workflows/meet.py`:

```python
#  workflows/_helpers.py — new helper, full batch flow with diarization
async def stt_transcribe_diarized(
    sc: ServerContext,
    audio_path: Path,
    *,
    language_code: str = "unknown",
    num_speakers: int | None = None,
    metrics: ToolMetrics | None = None,
    ctx: Any = None,
) -> tuple[str, list[dict[str, Any]], str | None]:
    # create job → upload → start → poll → return (transcript, diarized_turns, lang)
```

```python
#  workflows/meet.py — new sv_meet tool
async def sv_meet(ctx, audio_path, language_code="unknown", num_speakers=None, llm_model="sarvam-30b"):
    flat_transcript, diarized_turns, detected_lang = await stt_transcribe_diarized(sc, path, ...)
    labeled_transcript, normalized_turns = _render_transcript(diarized_turns, flat_transcript)
    raw_llm = await llm_complete(sc, [system_prompt, user_transcript], max_tokens=1200, ...)
    summary, action_items, decisions = _parse_llm_sections(raw_llm)
    return {"transcript": ..., "diarized_turns": ..., "summary": ..., "action_items": ..., "decisions": ...}
```

Output shape:
```json
{
  "transcript": "Speaker 1: Good morning.\nSpeaker 2: Let's start.",
  "diarized_turns": [{"speaker": "Speaker 1", "text": "...", "start": 0.0, "end": 2.1}],
  "language_code": "hi-IN",
  "summary": "The team aligned on Q3 priorities...",
  "action_items": ["Alice to send spec by Friday"],
  "decisions": ["Launch date moved to October 1"],
  "observability": {}
}
```

Falls back gracefully when the API returns no diarization data — uses the flat transcript for the LLM instead of failing.

## Tests

```
tests/tools/test_meet.py::test_render_transcript_maps_speaker_ids PASSED
tests/tools/test_meet.py::test_render_transcript_accepts_text_key PASSED
tests/tools/test_meet.py::test_render_transcript_falls_back_when_no_turns PASSED
tests/tools/test_meet.py::test_render_transcript_skips_empty_text_turns PASSED
tests/tools/test_meet.py::test_parse_llm_sections_full PASSED
tests/tools/test_meet.py::test_parse_llm_sections_none_placeholders PASSED
tests/tools/test_meet.py::test_parse_llm_sections_missing_sections PASSED
tests/tools/test_meet.py::test_extract_bullets_handles_numbered_list PASSED
tests/tools/test_meet.py::test_extract_bullets_handles_mixed_formats PASSED
tests/tools/test_meet.py::test_stt_transcribe_diarized_happy_path PASSED
tests/tools/test_meet.py::test_stt_transcribe_diarized_no_upload_urls_raises PASSED
tests/tools/test_registration.py::test_all_expected_tools_register PASSED

72 passed in 7.21s
```

All HTTP calls mocked with `httpx_mock` — no live API calls in the test suite.

## Scope / risk

- Touches `src/sarvam_mcp/workflows/_helpers.py` (additive — new function only, no existing function changed), `src/sarvam_mcp/workflows/meet.py` (new), `src/sarvam_mcp/workflows/__init__.py` (+1 import), `src/sarvam_mcp/server.py` (+1 line), `tests/tools/test_registration.py` (+1 entry), `tests/tools/test_meet.py` (new)
- No change to any atomic tool, existing workflow, auth, TTS, translate, transliterate, vision, LLM, observability, or audio sinks
- Backward-compatible: additive only — no existing tool name, parameter, or return shape is changed
