### PR TITLE
fix server registry version metadata

### DIFF
--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/sarvamai/sarvam-mcp",
     "source": "github"
   },
-  "version": "0.2.0",
+  "version": "0.2.8",
   "packages": [
     {
       "registry_type": "pypi",
       "registry_base_url": "https://pypi.org",
       "identifier": "sarvam-mcp",
-      "version": "0.2.0",
+      "version": "0.2.8",
       "transport": {
         "type": "stdio"
       },

--- a/tests/test_server_json.py
+++ b/tests/test_server_json.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_server_json_versions_match_package_version():
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    server = json.loads((ROOT / "server.json").read_text())
+
+    package_version = pyproject["project"]["version"]
+
+    assert server["version"] == package_version
+    assert server["packages"][0]["version"] == package_version


### PR DESCRIPTION
## Summary
  - Add a regression test to ensure `server.json` stays in sync with `pyproject.toml`

  ## Why

  `pyproject.toml` currently advertises package version `0.2.8`, but `server.json` still listed `0.2.0` in both the top-level `version` field and
  `packages[0].version`.

  Since `server.json` is registry metadata, keeping it in sync avoids clients or registries seeing stale package information.

  ## Test

  ```bash
  uv run --extra dev pytest tests/test_server_json.py -q

  1 passed