### PR TITLE
fix:readme tool names

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,20 +81,20 @@ All defaults below reflect the latest non-deprecated models.
 
 | Tool | What it does | Default model |
 |---|---|---|
-| `sarvam_stt_transcribe` | Audio file → transcript (5 modes) | `saaras:v3` |
-| `sarvam_tts_speak` | Text → audio file | `bulbul:v3` |
-| `sarvam_tts_stream` | Text → streamed audio | `bulbul:v3` |
-| `sarvam_translate` | Cross-language text translate | `mayura:v1` |
-| `sarvam_transliterate` | Script conversion | — |
-| `sarvam_identify_language` | Language + script detect | — |
-| `sarvam_text_analytics` | Typed Q&A over text | — |
-| `sarvam_llm_complete` | Chat completions | `sarvam-30b` |
-| `sarvam_vision_extract` | Document Intelligence | Sarvam Vision |
-| `sarvam_vision_job_status` | Poll Document Intelligence job | — |
-| `sarvam_pronunciation_list` | List pronunciation dictionaries | — |
-| `sarvam_pronunciation_get` | Get a pronunciation dictionary | — |
-| `sarvam_pronunciation_create` | Create a pronunciation dictionary | — |
-| `sarvam_pronunciation_delete` | Delete a pronunciation dictionary | — |
+| `sarvam_tools_stt_transcribe` | Audio file → transcript (5 modes) | `saaras:v3` |
+| `sarvam_tools_tts_speak` | Text → audio file | `bulbul:v3` |
+| `sarvam_tools_tts_stream` | Text → streamed audio | `bulbul:v3` |
+| `sarvam_tools_translate` | Cross-language text translate | `mayura:v1` |
+| `sarvam_tools_transliterate` | Script conversion | — |
+| `sarvam_tools_identify_language` | Language + script detect | — |
+| `sarvam_tools_text_analytics` | Typed Q&A over text | — |
+| `sarvam_tools_llm_complete` | Chat completions | `sarvam-30b` |
+| `sarvam_tools_vision_extract` | Document Intelligence | Sarvam Vision |
+| `sarvam_tools_vision_job_status` | Poll Document Intelligence job | — |
+| `sarvam_tools_pronunciation_list` | List pronunciation dictionaries | — |
+| `sarvam_tools_pronunciation_get` | Get a pronunciation dictionary | — |
+| `sarvam_tools_pronunciation_create` | Create a pronunciation dictionary | — |
+| `sarvam_tools_pronunciation_delete` | Delete a pronunciation dictionary | — |
 
 ## Configuration
 

--- a/src/sarvam_mcp/tools/stt.py
+++ b/src/sarvam_mcp/tools/stt.py
@@ -46,7 +46,7 @@ def register(mcp: FastMCP) -> None:
             "  • `codemix` — English words in English, Indic words in native script\n\n"
             "The default `language_code='unknown'` auto-detects, but specifying the "
             "language (e.g. `hi-IN`, `ta-IN`) gives better accuracy.\n"
-            "For very long files (>30s), prefer `sarvam_stt_batch_submit`."
+            "For very long files (>30s), prefer `sarvam_tools_stt_batch_submit`."
         ),
     )
     async def sarvam_stt_transcribe(
@@ -354,7 +354,7 @@ def register(mcp: FastMCP) -> None:
     )
     async def sarvam_stt_batch_status(
         ctx: Context,
-        job_id: str = Field(description="The job_id returned by sarvam_stt_batch_submit."),
+        job_id: str = Field(description="The job_id returned by sarvam_tools_stt_batch_submit."),
     ) -> dict[str, Any]:
         sc = await ready_ctx(ctx)
         with measure_tool() as metrics:


### PR DESCRIPTION
## Summary

  Fix stale MCP tool names in the README and STT tool descriptions.

  The README tools table was documenting runtime tools without the `sarvam_tools_*` namespace, for example:

  - `sarvam_stt_transcribe`
  - `sarvam_tts_speak`
  - `sarvam_translate`

  However, the actual registered MCP tools use the `sarvam_tools_*` namespace:

  - `sarvam_tools_stt_transcribe`
  - `sarvam_tools_tts_speak`
  - `sarvam_tools_translate`

  This PR updates the documented names to match the tools exposed by the server.

  ## Why

  The README is likely the first place users look when trying to call tools from an MCP client. If it lists tool names that are not actually registered,
  users may try to invoke tools that do not exist.

  The README also already says runtime tools live under the `sarvam_tools_*` namespace, so this change makes the tools table consistent with that documented
  namespace.

  ## Changes

  - Updated the README tools table to use the actual `sarvam_tools_*` names.
  - Fixed two STT tool-description references:
    - `sarvam_stt_batch_submit` → `sarvam_tools_stt_batch_submit`

  ## Verification

  I checked the registered tool names from the FastMCP server and confirmed the documented names exist.

  I also ran the test suite:

  ```bash
  uv run --extra dev pytest -q

  Result:

  61 passed in 5.26s