### PR TITLE
Expand registration smoke test to cover all MCP tools

### DIFF
--- a/tests/tools/test_registration.py
+++ b/tests/tools/test_registration.py
@@ -9,6 +9,14 @@ from __future__ import annotations
 EXPECTED_TOOLS = {
     # API key management
     "sarvam_tools_set_api_key",
+    # Build-time helpers — no Sarvam API call / no auth required
+    "sarvam_code_api_reference",
+    "sarvam_code_languages",
+    "sarvam_code_pricing",
+    "sarvam_code_recommend_model",
+    "sarvam_code_snippet",
+    "sarvam_code_speakers",
+    "sarvam_code_validate_request",
     # Atomic — one tool per Sarvam endpoint
     "sarvam_tools_stt_transcribe",
     "sarvam_tools_stt_translate",
@@ -22,6 +30,13 @@ EXPECTED_TOOLS = {
     "sarvam_tools_text_analytics",
     "sarvam_tools_llm_complete",
     "sarvam_tools_vision_extract",
+    "sarvam_tools_vision_job_status",
+    "sarvam_tools_pronunciation_list",
+    "sarvam_tools_pronunciation_get",
+    "sarvam_tools_pronunciation_create",
+    "sarvam_tools_pronunciation_delete",
+    # Maintenance
+    "sarvam_tools_upgrade",
     # Composite /sv-* workflows
     "sarvam_tools_voice",
     "sarvam_tools_dub",
@@ -43,4 +58,7 @@ async def test_all_expected_tools_register():
         names = set(server._tool_manager._tools.keys())  # type: ignore[attr-defined]
 
     missing = EXPECTED_TOOLS - names
-    assert not missing, f"Tools failed to register: {missing}"
+    assert not missing, f"Tools failed to register: {sorted(missing)}"
+
+    unexpected = names - EXPECTED_TOOLS
+    assert not unexpected, f"Registered tools missing from EXPECTED_TOOLS: {sorted(unexpected)}"


### PR DESCRIPTION
## Summary

  Expand the FastMCP registration smoke test so it covers the full public tool surface.

  ## Problem

  The existing registration test only checked a subset of registered tools. Several tools were omitted, including:

  - `sarvam_code_*` build-time helpers
  - pronunciation dictionary tools
  - `sarvam_tools_vision_job_status`
  - `sarvam_tools_upgrade`

  This meant a broken import or registration path for those tools could go unnoticed by the smoke test.

  ## Solution
  - Added an assertion for unexpected registered tools, so future tool additions update the expected list intentionally
  - Sorted assertion output for easier debugging

  ## Testing

  ```bash
  uv run --extra dev pytest -q

  Result:

  61 passed in 5.64s

  Also ran git diff --check.

  ## Limitations

  This test verifies tool registration names only. It does not validate each tool’s runtime API behavior.
