### PR TITLE
fix(tools): correct stale tool names in runtime tool descriptions

### DIFF
--- a/src/sarvam_mcp/tools/stt.py
+++ b/src/sarvam_mcp/tools/stt.py
@@ -46,7 +46,7 @@ def register(mcp: FastMCP) -> None:
             "  • `codemix` — English words in English, Indic words in native script\n\n"
             "The default `language_code='unknown'` auto-detects, but specifying the "
             "language (e.g. `hi-IN`, `ta-IN`) gives better accuracy.\n"
-            "For very long files (>30s), prefer `sarvam_stt_batch_submit`."
+            "For very long files (>30s), prefer `sarvam_tools_stt_batch_submit`."
         ),
     )
     async def sarvam_stt_transcribe(
@@ -354,7 +354,7 @@ def register(mcp: FastMCP) -> None:
     )
     async def sarvam_stt_batch_status(
         ctx: Context,
-        job_id: str = Field(description="The job_id returned by sarvam_stt_batch_submit."),
+        job_id: str = Field(description="The job_id returned by sarvam_tools_stt_batch_submit."),
     ) -> dict[str, Any]:
         sc = await ready_ctx(ctx)
         with measure_tool() as metrics:

--- a/src/sarvam_mcp/tools/tts.py
+++ b/src/sarvam_mcp/tools/tts.py
@@ -103,7 +103,7 @@ def register(mcp: FastMCP) -> None:
         name="sarvam_tools_tts_stream",
         description=(
             "Runtime tool — calls Sarvam API now. For code-writing help, use sarvam_code_* tools.\n\n"
-            "Streaming variant of sarvam_tts_speak using the TTS WebSocket. "
+            "Streaming variant of sarvam_tools_tts_speak using the TTS WebSocket. "
             "Audio is streamed to disk in the background; the tool returns a "
             "sarvam:// resource URI immediately."
         ),

--- a/tests/tools/test_tool_name_references.py
+++ b/tests/tools/test_tool_name_references.py
@@ -1,0 +1,52 @@
+"""Every `sarvam_*` tool name mentioned in a tool description must be real.
+
+Tool descriptions and parameter descriptions are read by the LLM to decide
+which tool to call and how to chain them. A stale name like
+``sarvam_stt_batch_submit`` (missing the ``tools_`` namespace) sends the
+agent after a tool that doesn't exist, so the guidance silently breaks.
+"""
+
+from __future__ import annotations
+
+import re
+
+from sarvam_mcp.server import build_server
+
+# Matches a full namespaced reference (`sarvam_tools_x`, `sarvam_code_x`) as
+# well as a stale/wrong one (`sarvam_stt_x`). The negative lookahead stops the
+# match before a `*`, so the namespace-wildcard phrases ``sarvam_tools_*`` /
+# ``sarvam_code_*`` are captured as the bare namespaces and skipped below.
+_TOOL_REF = re.compile(r"sarvam_[a-z0-9_]+(?<!_)")
+
+# Namespace wildcards, not references to a specific tool.
+_NAMESPACE_WILDCARDS = {"sarvam_tools", "sarvam_code"}
+
+
+def _descriptions(tool) -> list[str]:
+    texts: list[str] = []
+    if tool.description:
+        texts.append(tool.description)
+    props = (tool.parameters or {}).get("properties", {})
+    for prop in props.values():
+        desc = prop.get("description")
+        if desc:
+            texts.append(desc)
+    return texts
+
+
+async def test_tool_descriptions_only_reference_real_tools():
+    server = build_server()
+    tools = await server.list_tools()
+    registered = {t.name for t in tools}
+
+    bad: list[str] = []
+    for tool in tools:
+        for text in _descriptions(tool):
+            for ref in _TOOL_REF.findall(text):
+                # Skip `sarvam_tools_*` / `sarvam_code_*` wildcard phrasing.
+                if ref in _NAMESPACE_WILDCARDS:
+                    continue
+                if ref not in registered:
+                    bad.append(f"{tool.name}: references unknown tool '{ref}'")
+
+    assert not bad, "Tool descriptions reference tools that aren't registered:\n" + "\n".join(bad)


### PR DESCRIPTION
### Problem

Three MCP tool descriptions reference tools by names that are **not registered**, because they omit the `sarvam_tools_` namespace. Tool descriptions (and parameter descriptions) are read by the LLM to decide which tool to call and how to chain them, so an agent following this guidance is sent after a tool that doesn't exist and the call fails with "tool not found".

| Location | Referenced (wrong) | Actual registered tool |
|---|---|---|
| `tools/stt.py` — `stt_transcribe` description | `sarvam_stt_batch_submit` | `sarvam_tools_stt_batch_submit` |
| `tools/stt.py` — `stt_batch_status` `job_id` param | `sarvam_stt_batch_submit` | `sarvam_tools_stt_batch_submit` |
| `tools/tts.py` — `tts_stream` description | `sarvam_tts_speak` | `sarvam_tools_tts_speak` |

All registered runtime tools use the `sarvam_tools_*` namespace, so these bare names never resolve.

### Fix

Correct the three references to their real, registered names. No runtime/behaviour change — description strings only.

### Test

Adds `tests/tools/test_tool_name_references.py`: it builds the server, enumerates all registered tools, and scans every tool description **and** parameter description for `sarvam_*` references, asserting each resolves to a registered tool (namespace-wildcard phrasing like `sarvam_tools_*` is skipped).

Verified the test genuinely reproduces the bug — it **fails** on the current strings and **passes** after the fix:

```
# before fix (bug reintroduced):
FAILED tests/tools/test_tool_name_references.py
  sarvam_tools_stt_transcribe: references unknown tool 'sarvam_stt_batch_submit'

# after fix:
1 passed
```

Full suite: `60 passed` (the 2 `test_config.py` failures are pre-existing Windows-only `HOME`/`USERPROFILE` cases, unrelated to this change; green on the ubuntu CI). `ruff check` and `ruff format --check` clean on the changed/new files.

### Notes

- This is a **different surface** from the README tool-name fixes (#35 / #50) — those correct human-facing docs; this corrects the tool descriptions the LLM consumes at runtime.
- Confirmed not covered by any in-flight branch: the newest feature branches (`feat/structured-error-observability`, `fix/minor_cleanup`) still carry all three strings, and #51 expands the registration smoke test only (it does not scan descriptions).
