### PR TITLE
fix(server): don't block startup on the PyPI update check

### DIFF
--- a/src/sarvam_mcp/server.py
+++ b/src/sarvam_mcp/server.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import sys
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 
 from fastmcp import FastMCP
 from fastmcp.server.middleware import Middleware
@@ -51,15 +52,23 @@ async def _lifespan(_server: FastMCP) -> AsyncIterator[ServerContext]:
     client = SarvamClient(config.base_url)
     sink = build_sink(config.output_mode, config.base_path)
 
-    update_info = await check_pypi_version(__version__)
-    ctx = ServerContext(config=config, client=client, audio_sink=sink, update_info=update_info)
+    ctx = ServerContext(config=config, client=client, audio_sink=sink)
 
-    if update_info.update_available:
-        logger.info(
-            "Update available: v%s → v%s  (pip install --upgrade sarvam-mcp)",
-            update_info.current,
-            update_info.latest,
-        )
+    # Best-effort PyPI update check, run in the background so a slow or
+    # unreachable PyPI never blocks server startup. ``update_info`` stays
+    # ``None`` until it completes; ``sarvam_tools_upgrade`` already handles
+    # that case.
+    async def _check_for_update() -> None:
+        info = await check_pypi_version(__version__)
+        ctx.update_info = info
+        if info.update_available:
+            logger.info(
+                "Update available: v%s → v%s  (pip install --upgrade sarvam-mcp)",
+                info.current,
+                info.latest,
+            )
+
+    update_task = asyncio.create_task(_check_for_update())
 
     logger.info(
         "sarvam-mcp ready · v%s · base_url=%s output_mode=%s base_path=%s auth=%s",
@@ -72,6 +81,9 @@ async def _lifespan(_server: FastMCP) -> AsyncIterator[ServerContext]:
     try:
         yield ctx
     finally:
+        update_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await update_task
         await client.aclose()
 
 

--- a/src/sarvam_mcp/tools/update.py
+++ b/src/sarvam_mcp/tools/update.py
@@ -37,7 +37,11 @@ class UpdateInfo:
 
 
 async def check_pypi_version(current_version: str, *, timeout: float = 5.0) -> UpdateInfo:
-    """Non-blocking PyPI version lookup.  Returns ``UpdateInfo``; never raises."""
+    """Best-effort PyPI version lookup.  Returns ``UpdateInfo``; never raises.
+
+    Awaits a network GET (bounded by ``timeout``), so the server schedules it
+    as a background task rather than on the startup path.
+    """
     info = UpdateInfo(current=current_version)
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(timeout)) as client:

--- a/tests/test_server_lifespan.py
+++ b/tests/test_server_lifespan.py
@@ -1,0 +1,55 @@
+"""The server lifespan must not block startup on the PyPI update check.
+
+The update lookup is best-effort telemetry; a slow or unreachable PyPI must
+never delay the MCP server becoming ready to serve tools. The check runs in
+the background and populates ``update_info`` when it finishes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from sarvam_mcp.server import _lifespan, build_server
+from sarvam_mcp.tools import update as update_mod
+from sarvam_mcp.tools.update import UpdateInfo
+
+
+async def test_startup_does_not_block_on_pypi_check(monkeypatch):
+    release = asyncio.Event()
+    started = asyncio.Event()
+
+    async def blocking_check(current_version: str, *, timeout: float = 5.0) -> UpdateInfo:
+        started.set()
+        await release.wait()  # stand in for a slow/unreachable PyPI
+        return UpdateInfo(current=current_version, latest="99.0.0", update_available=True)
+
+    monkeypatch.setattr(update_mod, "check_pypi_version", blocking_check)
+
+    server = build_server()
+    cm = _lifespan(server)
+
+    # Startup must complete even though the PyPI check is still blocked. If the
+    # check were awaited on the startup path, __aenter__ would hang here and
+    # wait_for would raise TimeoutError.
+    ctx = await asyncio.wait_for(cm.__aenter__(), timeout=2.0)
+    try:
+        # Startup returned without the check finishing (it's still blocked).
+        assert ctx.update_info is None, "startup must not wait for the check to finish"
+
+        # The check is scheduled — it starts once the loop gets a tick.
+        for _ in range(100):
+            if started.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert started.is_set(), "update check should have been scheduled"
+
+        # Let the background check complete; update_info should then populate.
+        release.set()
+        for _ in range(200):
+            if ctx.update_info is not None:
+                break
+            await asyncio.sleep(0.01)
+        assert ctx.update_info is not None
+        assert ctx.update_info.update_available
+    finally:
+        await cm.__aexit__(None, None, None)


### PR DESCRIPTION
### Problem

The server lifespan **awaited** the PyPI update check before yielding the server context:

```python
# server.py — _lifespan, before yield
update_info = await check_pypi_version(__version__)
ctx = ServerContext(..., update_info=update_info)
...
yield ctx
```

`check_pypi_version` opens an `httpx` client and does a `GET https://pypi.org/pypi/sarvam-mcp/json` with a 5s timeout. Because it's awaited on the startup path, **the MCP server does not become ready until PyPI responds**. `sarvam-mcp` is cold-started over stdio by MCP clients (Claude Desktop, Cursor, …) on every launch, so:

- **Offline / DNS-slow / PyPI-degraded** → every startup stalls up to the full ~5s before any tool is available.
- The helper's own docstring called it a *"Non-blocking PyPI version lookup"* — but as wired, it blocked readiness.

### Fix

Run the check as a **background task** so startup never waits on a third-party network call:

- `update_info` stays `None` until the check completes — and `sarvam_tools_upgrade` **already** handles that (`"Version check … hasn't completed yet"`), so this is the intended shape.
- No behaviour lost: the check still runs and populates `update_info`; the "update available" log still fires; the task is cancelled cleanly on shutdown.
- Docstring corrected to describe the actual (awaits-a-GET, schedule-off-startup) contract.

### Test

`tests/test_server_lifespan.py` drives the lifespan with a check that blocks on an event and asserts:
1. `__aenter__` returns (server ready) **without** waiting for the check — via `asyncio.wait_for(..., timeout=2.0)`;
2. `update_info` is `None` at that point;
3. once the check is released, `update_info` populates.

Verified it genuinely reproduces the bug — with the blocking `await` restored, startup hangs and the test **fails with `TimeoutError`**; with the fix it **passes**:

```
# blocking version:  FAILED tests/test_server_lifespan.py … TimeoutError
# fixed version:     1 passed
```

Full suite: `60 passed` (the 2 `test_config.py` failures are pre-existing Windows-only `HOME`/`USERPROFILE` cases, unrelated; green on ubuntu CI). `ruff check` / `ruff format --check` clean on changed/new files.

### Notes

Confirmed not covered elsewhere: every in-flight branch (`feat/metrics` — which rewrites `server.py` — plus `feat/structured-error-observability` and `fix/minor_cleanup`) still awaits `check_pypi_version` before `yield`.
