### PR TITLE
fix(tts): don't send bulbul:v2-only pitch/loudness to bulbul:v3

### DIFF
--- a/src/sarvam_mcp/tools/tts.py
+++ b/src/sarvam_mcp/tools/tts.py
@@ -48,9 +48,15 @@ def register(mcp: FastMCP) -> None:
         speech_sample_rate: SampleRate = Field(
             default=24000, description="PCM sample rate of the output WAV."
         ),
-        pitch: float = Field(default=0.0, ge=-1.0, le=1.0),
+        pitch: float = Field(
+            default=0.0, ge=-1.0, le=1.0,
+            description="bulbul:v2 only — ignored by bulbul:v3.",
+        ),
         pace: float = Field(default=1.0, ge=0.3, le=3.0),
-        loudness: float = Field(default=1.0, ge=0.1, le=3.0),
+        loudness: float = Field(
+            default=1.0, ge=0.1, le=3.0,
+            description="bulbul:v2 only — ignored by bulbul:v3.",
+        ),
         enable_preprocessing: bool = Field(
             default=True,
             description="Normalize numbers/dates/code-mixed segments before synthesis.",
@@ -61,17 +67,17 @@ def register(mcp: FastMCP) -> None:
         ),
     ) -> dict[str, Any]:
         sc = await ready_ctx(ctx)
-        body: dict[str, Any] = {
-            "inputs": [text],
-            "target_language_code": target_language_code,
-            "speaker": speaker,
-            "speech_sample_rate": speech_sample_rate,
-            "pitch": pitch,
-            "pace": pace,
-            "loudness": loudness,
-            "enable_preprocessing": enable_preprocessing,
-            "model": model,
-        }
+        body = _speak_body(
+            text=text,
+            target_language_code=target_language_code,
+            speaker=speaker,
+            speech_sample_rate=speech_sample_rate,
+            pitch=pitch,
+            pace=pace,
+            loudness=loudness,
+            enable_preprocessing=enable_preprocessing,
+            model=model,
+        )
 
         with measure_tool() as metrics:
             payload, call = await sc.client.post_json(TTS_PATH, json_body=body)
@@ -177,6 +183,39 @@ def register(mcp: FastMCP) -> None:
             "completed_at": time.time(),
             "observability": metrics.to_response_block(),
         }
+
+
+def _speak_body(
+    *,
+    text: str,
+    target_language_code: str,
+    speaker: str,
+    speech_sample_rate: int,
+    pitch: float,
+    pace: float,
+    loudness: float,
+    enable_preprocessing: bool,
+    model: str,
+) -> dict[str, Any]:
+    """Build the /text-to-speech request body.
+
+    ``pitch`` and ``loudness`` are bulbul:v2-only parameters — bulbul:v3
+    does not support them, so they are omitted for v3 rather than sent and
+    silently ignored.
+    """
+    body: dict[str, Any] = {
+        "inputs": [text],
+        "target_language_code": target_language_code,
+        "speaker": speaker,
+        "speech_sample_rate": speech_sample_rate,
+        "pace": pace,
+        "enable_preprocessing": enable_preprocessing,
+        "model": model,
+    }
+    if model != "bulbul:v3":
+        body["pitch"] = pitch
+        body["loudness"] = loudness
+    return body
 
 
 def _ws_request_payload(

--- a/tests/tools/test_tts_body.py
+++ b/tests/tools/test_tts_body.py
@@ -1,0 +1,39 @@
+"""The /text-to-speech request body must only carry parameters the model supports.
+
+``pitch`` and ``loudness`` are bulbul:v2-only. bulbul:v3 (the default and only
+currently-exposed model) does not support them, so they must not be sent.
+``pace``, which v3 does support, must still be included.
+"""
+
+from __future__ import annotations
+
+from sarvam_mcp.tools.tts import _speak_body
+
+_COMMON = dict(
+    text="नमस्ते",
+    target_language_code="hi-IN",
+    speaker="priya",
+    speech_sample_rate=24000,
+    pitch=0.5,
+    pace=1.25,
+    loudness=2.0,
+    enable_preprocessing=True,
+)
+
+
+def test_v3_body_omits_pitch_and_loudness():
+    body = _speak_body(model="bulbul:v3", **_COMMON)
+    assert "pitch" not in body
+    assert "loudness" not in body
+    # Supported params are still present.
+    assert body["pace"] == 1.25
+    assert body["inputs"] == ["नमस्ते"]
+    assert body["model"] == "bulbul:v3"
+    assert body["speech_sample_rate"] == 24000
+
+
+def test_non_v3_model_still_sends_pitch_and_loudness():
+    # Future-proofing: a v2-style model keeps the full parameter set.
+    body = _speak_body(model="bulbul:v2", **_COMMON)
+    assert body["pitch"] == 0.5
+    assert body["loudness"] == 2.0


### PR DESCRIPTION
### Problem

`sarvam_tools_tts_speak` sends `pitch` and `loudness` on **every** `/text-to-speech` request:

```python
body = {
    ...
    "pitch": pitch,
    "pace": pace,
    "loudness": loudness,
    ...
    "model": model,   # bulbul:v3 (the default and only exposed model)
}
```

Per the [official Bulbul TTS docs](https://docs.sarvam.ai/api-reference-docs/text-to-speech/convert), **`pitch` and `loudness` are `bulbul:v2`-only — unsupported by `bulbul:v3`**. So for the default model they're sent and silently ignored, and the tool advertises pitch/loudness knobs that do nothing on v3.

### Fix

Build the request body via a small `_speak_body()` helper that **omits `pitch`/`loudness` for `bulbul:v3`** while keeping them for other (v2-style) models, and label the two fields as v2-only in their descriptions. `pace` (which v3 *does* support) is unchanged. No parameters are removed from the tool signature, so this is **non-breaking** and future-proof if a v2 model is re-exposed.

**Safety:** the tool is deployed and working today while always sending these fields, so the API already tolerates (ignores) them — *removing* tolerated fields cannot break a working call. This also revives the uncontested idea from the closed #4 (whose only review feedback was ruff formatting), minus the unrelated sample-rate change and formatting churn.

### Test

`tests/tools/test_tts_body.py` asserts the v3 body excludes `pitch`/`loudness` and keeps `pace`/`inputs`/`model`, and that a non-v3 model still carries the full set.

Full suite green (only the 2 pre-existing Windows-only `test_config.py` failures remain, unrelated; green on ubuntu CI). `ruff check` / `ruff format --check` clean.

Confirmed not covered elsewhere: `feat/metrics`, `feat/structured-error-observability`, and `fix/minor_cleanup` all still send `pitch`/`loudness` unconditionally.
