### PR TITLE
fix(auth): surface Windows credential-permission failures instead of failing silently

### DIFF
--- a/src/sarvam_mcp/tools/auth.py
+++ b/src/sarvam_mcp/tools/auth.py
@@ -7,7 +7,9 @@ future sessions.
 
 from __future__ import annotations
 
+import logging
 import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -17,6 +19,8 @@ from pydantic import Field
 
 from sarvam_mcp.auth.api_key import StaticKeyProvider
 from sarvam_mcp.auth.context import set_auth
+
+logger = logging.getLogger("sarvam_mcp.auth")
 
 CREDENTIALS_PATH = Path("~/.sarvam/credentials").expanduser()
 DASHBOARD_URL = "https://dashboard.sarvam.ai/key-management"
@@ -110,15 +114,37 @@ def _save_key(api_key: str) -> None:
 def _restrict_permissions(path: Path) -> None:
     """Set file to owner-only access on all platforms."""
     if sys.platform == "win32":
-        # On Windows, use icacls to restrict to current user only.
-        import subprocess
-
-        username = os.environ.get("USERNAME", "")
-        if username:
-            subprocess.run(
-                ["icacls", str(path), "/inheritance:r",
-                 "/grant:r", f"{username}:(R,W)"],
-                capture_output=True,
-            )
+        _restrict_permissions_windows(path)
     else:
         os.chmod(path, 0o600)
+
+
+def _restrict_permissions_windows(path: Path) -> None:
+    """Restrict ``path`` to the current user via ``icacls``.
+
+    The POSIX ``chmod`` path raises loudly on failure; mirror that here by
+    surfacing a warning instead of silently leaving the credentials file with
+    inherited (potentially world-readable) permissions.
+    """
+    username = os.environ.get("USERNAME", "")
+    if not username:
+        logger.warning(
+            "Could not restrict permissions on %s: USERNAME is not set, so the "
+            "credentials file may be readable by other users on this machine.",
+            path,
+        )
+        return
+
+    result = subprocess.run(
+        ["icacls", str(path), "/inheritance:r", "/grant:r", f"{username}:(R,W)"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        logger.warning(
+            "Could not restrict permissions on %s (icacls exited %d): %s — the "
+            "credentials file may be readable by other users on this machine.",
+            path,
+            result.returncode,
+            (result.stderr or result.stdout).strip(),
+        )

--- a/tests/test_auth_perms.py
+++ b/tests/test_auth_perms.py
@@ -1,0 +1,67 @@
+"""Windows credential-permission hardening must fail loudly, not silently.
+
+On POSIX ``os.chmod`` raises on failure; the Windows ``icacls`` path used to
+swallow every failure, leaving the API-key file with inherited permissions and
+no signal. These tests pin the warning behaviour (and run on any platform by
+calling the Windows helper directly).
+"""
+
+from __future__ import annotations
+
+from sarvam_mcp.tools import auth as auth_mod
+from sarvam_mcp.tools.auth import _restrict_permissions_windows
+
+
+class _FakeResult:
+    def __init__(self, returncode: int, stderr: str = "", stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+        self.stdout = stdout
+
+
+def test_warns_when_username_missing(monkeypatch, caplog, tmp_path):
+    monkeypatch.delenv("USERNAME", raising=False)
+    called = False
+
+    def _should_not_run(*args, **kwargs):
+        nonlocal called
+        called = True
+        return _FakeResult(0)
+
+    monkeypatch.setattr(auth_mod.subprocess, "run", _should_not_run)
+
+    path = tmp_path / "credentials"
+    path.write_text("api_key = sk_x\n")
+    with caplog.at_level("WARNING"):
+        _restrict_permissions_windows(path)
+
+    assert not called, "icacls must not run without a username"
+    assert any("restrict permissions" in r.message.lower() for r in caplog.records)
+
+
+def test_warns_when_icacls_fails(monkeypatch, caplog, tmp_path):
+    monkeypatch.setenv("USERNAME", "tester")
+    monkeypatch.setattr(
+        auth_mod.subprocess, "run", lambda *a, **k: _FakeResult(5, stderr="Access is denied.")
+    )
+
+    path = tmp_path / "credentials"
+    path.write_text("api_key = sk_x\n")
+    with caplog.at_level("WARNING"):
+        _restrict_permissions_windows(path)
+
+    messages = " ".join(r.message.lower() for r in caplog.records)
+    assert "restrict permissions" in messages
+    assert "access is denied" in messages
+
+
+def test_silent_on_success(monkeypatch, caplog, tmp_path):
+    monkeypatch.setenv("USERNAME", "tester")
+    monkeypatch.setattr(auth_mod.subprocess, "run", lambda *a, **k: _FakeResult(0))
+
+    path = tmp_path / "credentials"
+    path.write_text("api_key = sk_x\n")
+    with caplog.at_level("WARNING"):
+        _restrict_permissions_windows(path)
+
+    assert not caplog.records, "success path must not warn"


### PR DESCRIPTION
### Problem

`sarvam_tools_set_api_key` saves the key to `~/.sarvam/credentials` and then calls `_restrict_permissions` to make it owner-only. On Windows that path silently no-ops in two ways:

```python
username = os.environ.get("USERNAME", "")
if username:
    subprocess.run(["icacls", ..., f"{username}:(R,W)"], capture_output=True)
# else: nothing — and no return-code check either
```

1. If `USERNAME` is unset (services, some CI, stripped env), the `if username:` guard skips restriction entirely.
2. `capture_output=True` with no return-code check swallows any `icacls` failure (SID resolution, locale, `DOMAIN\user` mismatch).

Either way the credentials file keeps its inherited (potentially readable-by-others) permissions with **no signal** — while the POSIX branch (`os.chmod(path, 0o600)`) fails loudly.

### Fix

Extract `_restrict_permissions_windows` and make it **log a warning** when the username can't be resolved or `icacls` exits non-zero, mirroring the POSIX branch's loud failure. The success path is unchanged (no behaviour change when it works). This doesn't weaken or alter a working setup — it just makes the failure observable so a user knows their key file wasn't locked down.

### Test

`tests/test_auth_perms.py` calls the Windows helper directly (so it runs on any platform) and covers:
- missing `USERNAME` → warns, and `icacls` is not invoked;
- `icacls` exits non-zero → warns and includes the error text;
- success → no warning.

Full suite green (only the 2 pre-existing Windows-only `test_config.py` failures remain, unrelated). `ruff check` / `ruff format --check` clean.
