### PR TITLE
fix(docs): correct model-specific translate limit and pronunciation endpoint reference

### DIFF
--- a/src/sarvam_mcp/code/_data.py
+++ b/src/sarvam_mcp/code/_data.py
@@ -296,7 +296,7 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
             "dictionary_count": "int",
             "dictionaries":     "list[str] — dictionary IDs",
         },
-        "notes": "CRUD for pronunciation dictionaries. Also supports GET /{id}, PUT /{id}, DELETE /{id}.",
+        "notes": "CRUD for pronunciation dictionaries. GET /{id} takes the id as a path param; PUT and DELETE take it as a query param (?dict_id={id}).",
     },
 }
 

--- a/src/sarvam_mcp/tools/translate.py
+++ b/src/sarvam_mcp/tools/translate.py
@@ -39,7 +39,12 @@ def register(mcp: FastMCP) -> None:
     )
     async def sarvam_translate(
         ctx: Context,
-        input: str = Field(description="Text to translate (max ~2000 chars)."),
+        input: str = Field(
+            description=(
+                "Text to translate. Max ~1000 chars for `mayura:v1` (the default); "
+                "~2000 for `sarvam-translate:v1`."
+            ),
+        ),
         source_language_code: LanguageCode = Field(
             description="Source BCP-47 code, or 'auto' to auto-detect.",
         ),

--- a/tests/code/test_data.py
+++ b/tests/code/test_data.py
@@ -28,6 +28,15 @@ def test_default_speaker_priya_is_v3():
     assert "priya" in _data.V3_SPEAKERS
 
 
+def test_pronunciation_reference_matches_runtime_delete_shape():
+    # The runtime delete tool passes the id as a query param
+    # (?dict_id=), not a path segment. The reference note must not tell
+    # code-gen agents to use the path form.
+    note = _data.API_REFERENCE["/text-to-speech/pronunciation-dictionary"]["notes"]
+    assert "dict_id" in note
+    assert "DELETE /{id}" not in note
+
+
 def test_pricing_table_covers_every_model_in_reference():
     referenced_models: set[str] = set()
     for _endpoint, ref in _data.API_REFERENCE.items():

--- a/tests/tools/test_translate_meta.py
+++ b/tests/tools/test_translate_meta.py
@@ -1,0 +1,17 @@
+"""The translate tool's input hint must reflect the default model's real limit.
+
+`mayura:v1` (the default) caps input at ~1000 chars; only `sarvam-translate:v1`
+allows ~2000. The field description must not advertise the higher limit as if
+it applied to the default.
+"""
+
+from __future__ import annotations
+
+from sarvam_mcp.server import build_server
+
+
+async def test_translate_input_hint_mentions_default_model_limit():
+    server = build_server()
+    tool = next(t for t in await server.list_tools() if t.name == "sarvam_tools_translate")
+    desc = tool.parameters["properties"]["input"]["description"]
+    assert "1000" in desc, "input hint should state mayura:v1's ~1000-char limit"


### PR DESCRIPTION
Two small agent-facing facts contradicted the [official Sarvam docs](https://docs.sarvam.ai). Both mislead the LLM/developer at code-gen time.

### 1. Translate input-length hint (wrong for the default model)

`sarvam_tools_translate`'s `input` field said *"max ~2000 chars"*, but the **default** model `mayura:v1` caps at **~1000 chars** — only `sarvam-translate:v1` allows ~2000 ([translate docs](https://docs.sarvam.ai/api-reference-docs/text/translate-text)). A caller trusting the hint sends ~1500 chars to the default and gets an API error. Now states both limits.

### 2. Pronunciation dictionary API reference (wrong verb shapes)

`sarvam_code_api_reference("/text-to-speech/pronunciation-dictionary")` returned a note claiming *"Also supports GET /{id}, **PUT /{id}, DELETE /{id}**"*. Per the [pronunciation docs](https://docs.sarvam.ai/api-reference-docs/api-guides-tutorials/text-to-speech/pronunciation-dictionary), **PUT and DELETE take the id as a `?dict_id={id}` query param** — only GET uses the path form. The runtime `sarvam_tools_pronunciation_delete` already uses the query form, so the reference was also internally inconsistent. An agent following it would generate `DELETE …/{id}` and hit the wrong endpoint.

### Tests

- `test_translate_input_hint_mentions_default_model_limit` — pins the input hint to the default model's ~1000 limit.
- `test_pronunciation_reference_matches_runtime_delete_shape` — asserts the reference note uses `dict_id` (query) and doesn't claim `DELETE /{id}` (path).

Full suite green (only the 2 pre-existing Windows-only `test_config.py` failures remain, unrelated). Confirmed not covered by any in-flight branch.

*(Two independent one-liners bundled since both are the same class — reference text that disagrees with the official docs. Happy to split if you'd prefer.)*
