### PR TITLE
fix tts stream audio response fields

### DIFF
--- a/src/sarvam_mcp/tools/tts.py
+++ b/src/sarvam_mcp/tools/tts.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 from fastmcp import Context, FastMCP
 from pydantic import Field
 
+from sarvam_mcp.audio import StoredAudio
 from sarvam_mcp.observability import measure_tool
 from sarvam_mcp.tools._common import BulbulSpeaker, TtsLanguageCode, ready_ctx
 
@@ -89,11 +90,7 @@ def register(mcp: FastMCP) -> None:
         )
 
         return {
-            "file_path": stored.file_path,
-            "resource_uri": stored.resource_uri,
-            "base64_data": stored.base64_data,
-            "mime_type": stored.mime_type,
-            "size_bytes": stored.size_bytes,
+            **_stored_audio_fields(stored),
             "speaker": speaker,
             "language": target_language_code,
             "observability": metrics.to_response_block(),
@@ -171,9 +168,7 @@ def register(mcp: FastMCP) -> None:
         )
 
         return {
-            "file_path": stored.file_path,
-            "resource_uri": stored.resource_uri,
-            "size_bytes": stored.size_bytes,
+            **_stored_audio_fields(stored),
             "completed_at": time.time(),
             "observability": metrics.to_response_block(),
         }
@@ -209,3 +204,13 @@ def _maybe_parse_event(frame: str) -> dict[str, Any]:
         return result if isinstance(result, dict) else {}
     except _json.JSONDecodeError:
         return {}
+
+
+def _stored_audio_fields(stored: StoredAudio) -> dict[str, Any]:
+    return {
+        "file_path": stored.file_path,
+        "resource_uri": stored.resource_uri,
+        "base64_data": stored.base64_data,
+        "mime_type": stored.mime_type,
+        "size_bytes": stored.size_bytes,
+    }

--- a/tests/tools/test_tts.py
+++ b/tests/tools/test_tts.py
@@ -1,0 +1,24 @@
+"""TTS tool response helpers."""
+
+from __future__ import annotations
+
+from sarvam_mcp.audio import StoredAudio
+from sarvam_mcp.tools.tts import _stored_audio_fields
+
+
+def test_stored_audio_fields_preserves_resource_payload():
+    stored = StoredAudio(
+        file_path=None,
+        resource_uri="sarvam://x.wav",
+        base64_data="ZmFrZS13YXY=",
+        mime_type="audio/wav",
+        size_bytes=8,
+    )
+
+    assert _stored_audio_fields(stored) == {
+        "file_path": None,
+        "resource_uri": "sarvam://x.wav",
+        "base64_data": "ZmFrZS13YXY=",
+        "mime_type": "audio/wav",
+        "size_bytes": 8,
+    }


### PR DESCRIPTION

• ## Summary

  Make `sarvam_tools_tts_stream` return the same stored-audio fields as `sarvam_tools_tts_speak`.

  ## Problem

  `SARVAM_AUDIO_OUTPUT_MODE` supports `files`, `resources`, and `both`.

  For resource-based output, `StoredAudio` includes fields such as:

  - `resource_uri`
  - `base64_data`
  - `mime_type`
  - `size_bytes`

  `sarvam_tools_tts_speak` already returned all of these fields, but `sarvam_tools_tts_stream` only returned:

  - `file_path`
  - `resource_uri`
  - `size_bytes`

  That meant clients using resource output could miss the base64 audio payload and MIME type from streaming TTS responses.

  ## Solution

  - Added a small `_stored_audio_fields()` helper for common `StoredAudio` response fields
  - Reused it in both REST and streaming TTS responses
  - Added a focused unit test for preserving resource-mode audio fields

  ## Testing

  ```bash
  uv run --extra dev pytest tests/tools/test_tts.py -q
  uv run --extra dev pytest -q
  uv run --extra dev ruff check src/sarvam_mcp/tools/tts.py tests/tools/test_tts.py

  Results:

  1 passed in 0.47s
  62 passed in 5.20s
  All checks passed!