### PR TITLE
fixes issue #48

### DIFF
--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/sarvamai/sarvam-mcp",
     "source": "github"
   },
-  "version": "0.2.0",
+  "version": "0.2.8",
   "packages": [
     {
       "registry_type": "pypi",
       "registry_base_url": "https://pypi.org",
       "identifier": "sarvam-mcp",
-      "version": "0.2.0",
+      "version": "0.2.8",
       "transport": {
         "type": "stdio"
       },

--- a/tests/test_server_json_version.py
+++ b/tests/test_server_json_version.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_SERVER_JSON = _REPO_ROOT / "server.json"
+
+
+def test_server_json_version_matches_pyproject():
+    """server.json is registry metadata — it must not drift from the package version."""
+    pyproject = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    pkg_version = pyproject["project"]["version"]
+
+    server_json = json.loads(_SERVER_JSON.read_text(encoding="utf-8"))
+
+    assert server_json["version"] == pkg_version, (
+        f"server.json top-level version {server_json['version']!r} "
+        f"does not match pyproject.toml {pkg_version!r}"
+    )
+
+    package = server_json["packages"][0]
+    assert package["version"] == pkg_version, (
+        f"server.json packages[0].version {package['version']!r} "
+        f"does not match pyproject.toml {pkg_version!r}"
+    )


### PR DESCRIPTION
Fixes #48. server.json (MCP registry metadata) advertised a stale 0.2.0 while the package is at 0.2.8, so registries/clients consuming it could pin or display an outdated version.

Changes made:
- server.json: bumped both version fields to 0.2.8 (top-level "version" and "packages"[0]."version").
- tests/test_server_json_version.py (new): asserts server.json's top-level and package versions equal the pyproject.toml version, so future drift is caught in CI.

Test plan:
- Repro from the issue now prints 0.2.8 / 0.2.8 / 0.2.8.
- uv run pytest -q tests/test_server_json_version.py → 1 passed.
- uv run ruff format --check tests/test_server_json_version.py → clean.

Note: the 2 failing tests in tests/test_config.py and the 5 ruff warnings in src/sarvam_mcp/tools/_common.py are pre-existing and unrelated to this change.