### PR TITLE
fix: close temp file handle before unlink in resolve_file_input

### DIFF
--- a/src/sarvam_mcp/tools/_common.py
+++ b/src/sarvam_mcp/tools/_common.py
@@ -59,28 +59,32 @@ async def resolve_file_input(
     tmp_path = Path(tmp.name)
     try:
         if file_base64 is not None:
-            data = base64.b64decode(file_base64)
-            if len(data) > max_bytes:
-                raise ValueError(
-                    f"Decoded file is {len(data)} bytes, exceeds {max_bytes} byte limit."
-                )
-            tmp.write(data)
-            tmp.close()
+            try:
+                data = base64.b64decode(file_base64)
+                if len(data) > max_bytes:
+                    raise ValueError(
+                        f"Decoded file is {len(data)} bytes, exceeds {max_bytes} byte limit."
+                    )
+                tmp.write(data)
+            finally:
+                tmp.close()
             yield tmp_path
         else:
             assert file_url is not None
-            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0)) as client:
-                async with client.stream("GET", file_url) as resp:
-                    resp.raise_for_status()
-                    downloaded = 0
-                    async for chunk in resp.aiter_bytes(chunk_size=65536):
-                        downloaded += len(chunk)
-                        if downloaded > max_bytes:
-                            raise ValueError(
-                                f"Downloaded file exceeds {max_bytes} byte limit."
-                            )
-                        tmp.write(chunk)
-            tmp.close()
+            try:
+                async with httpx.AsyncClient(timeout=httpx.Timeout(120.0)) as client:
+                    async with client.stream("GET", file_url) as resp:
+                        resp.raise_for_status()
+                        downloaded = 0
+                        async for chunk in resp.aiter_bytes(chunk_size=65536):
+                            downloaded += len(chunk)
+                            if downloaded > max_bytes:
+                                raise ValueError(
+                                    f"Downloaded file exceeds {max_bytes} byte limit."
+                                )
+                            tmp.write(chunk)
+            finally:
+                tmp.close()
             yield tmp_path
     finally:
         tmp_path.unlink(missing_ok=True)


### PR DESCRIPTION
##Fixes #59

## Bug

When `resolve_file_input` handles a URL download or a base64 string, the temporary file handle is only closed on the success path. If an exception occurs during the download, decoding, or validation process, `tmp.close()` is never called.

## Root cause

An unhandled cleanup block in `tools/_common.py`.

The file handle of the `tempfile.NamedTemporaryFile` was closed only at the end of the success path, but not inside a sub-`try/finally` block. When an exception was raised (e.g., HTTP status error, network error, or decoding/validation exceptions), the code skipped the `tmp.close()` call. The outer `finally` block then called `tmp_path.unlink(missing_ok=True)` on an open file handle.

### Before (buggy)

```python
tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
tmp_path = Path(tmp.name)
try:
    if file_base64 is not None:
        data = base64.b64decode(file_base64)
        if len(data) > max_bytes:
            raise ValueError(...)
        tmp.write(data)
        tmp.close()
        yield tmp_path
    else:
        assert file_url is not None
        async with httpx.AsyncClient(timeout=httpx.Timeout(120.0)) as client:
            async with client.stream("GET", file_url) as resp:
                resp.raise_for_status()
                downloaded = 0
                async for chunk in resp.aiter_bytes(chunk_size=65536):
                    downloaded += len(chunk)
                    if downloaded > max_bytes:
                        raise ValueError(...)
                    tmp.write(chunk)
        tmp.close()
        yield tmp_path
finally:
    tmp_path.unlink(missing_ok=True)
```

## Fix

Wrap both the base64 processing and URL download branches in inner `try/finally` blocks so `tmp.close()` is guaranteed to execute before the outer `finally` runs `unlink()`.

## Impact

- **Windows:** Any failed download or validation error throws a confusing `PermissionError: [WinError 32]` that masks the original exception, while permanently leaking both the open file descriptor and the temporary file on disk.
- **Linux/macOS:** Causes a file descriptor leak on every failed file resolution request.