### PR TITLE
fix(stt): call download-files to retrieve batch transcript

### DIFF
--- a/src/sarvam_mcp/tools/stt.py
+++ b/src/sarvam_mcp/tools/stt.py
@@ -318,26 +318,34 @@ def register(mcp: FastMCP) -> None:
                         "observability": metrics.to_response_block(),
                     }
 
-                # Step 6: Extract transcript
-                result = status_resp.get("result") or {}
-                transcript = result.get("transcript") or status_resp.get("transcript")
+                # Step 6: /status carries no transcript — fetch it via download-files.
+                result: dict[str, Any] = {}
+                output_files: list[str] = []
+                for task in status_resp.get("job_details", []):
+                    if task.get("state") == "Success":
+                        for out in task.get("outputs", []):
+                            output_files.append(out["file_name"])
 
-                if not transcript:
-                    download_urls = status_resp.get("download_urls", {})
+                if output_files:
+                    await ctx.info("Fetching download links…")
+                    download_resp, call = await sc.client.post_json(
+                        STT_JOB_DOWNLOAD,
+                        json_body={"job_id": job_id, "files": output_files},
+                    )
+                    metrics.merge(call)
+                    download_urls = download_resp.get("download_urls", {})
                     if download_urls:
                         await ctx.info("Downloading transcript…")
                         dl_url = next(iter(download_urls.values()))["file_url"]
                         async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as dl:
                             dl_resp = await dl.get(dl_url)
                         if dl_resp.is_success:
-                            dl_body = dl_resp.json()
-                            transcript = dl_body.get("transcript", "")
-                            result = dl_body
+                            result = dl_resp.json()
 
         return {
             "job_id": job_id,
             "job_state": status_resp.get("job_state"),
-            "transcript": transcript or "",
+            "transcript": result.get("transcript", ""),
             "language_code": result.get("language_code"),
             "diarized_transcript": result.get("diarized_transcript"),
             "timestamps": result.get("timestamps"),

--- a/tests/tools/test_stt.py
+++ b/tests/tools/test_stt.py
@@ -1,0 +1,230 @@
+"""sarvam_tools_stt_batch_submit — full job lifecycle including download.
+
+Regression coverage for a bug where the tool polled ``/status`` to
+``Completed`` but never called ``POST .../download-files``, so it always
+returned an empty transcript: ``/status`` never carries ``transcript``,
+``result``, or ``download_urls`` (confirmed against the live OpenAPI spec at
+docs.sarvam.ai) — only ``job_details[].outputs[].file_name``, which must be
+passed to ``download-files`` to get a signed URL for the actual output file.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from sarvam_mcp._registry import ServerContext
+from sarvam_mcp.audio.sinks import build_sink
+from sarvam_mcp.config import Config
+from sarvam_mcp.http import SarvamClient
+from sarvam_mcp.tools import stt
+
+BASE = "https://api.sarvam.ai"
+
+
+@pytest.fixture
+async def stt_server(tmp_path):
+    client = SarvamClient(BASE)
+
+    @asynccontextmanager
+    async def lifespan(_server):
+        try:
+            yield ServerContext(
+                config=Config(),
+                client=client,
+                audio_sink=build_sink("files", tmp_path),
+            )
+        finally:
+            await client.aclose()
+
+    mcp = FastMCP("test", lifespan=lifespan)
+    stt.register(mcp)
+    return mcp
+
+
+@pytest.fixture
+def audio_file(tmp_path):
+    path = tmp_path / "meeting.wav"
+    path.write_bytes(b"RIFF....WAVEfmt ")
+    return path
+
+
+def _mock_happy_path(httpx_mock, *, with_diarization=False):
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{BASE}/speech-to-text/job/v1",
+        json={
+            "job_id": "job-1",
+            "job_state": "Accepted",
+            "storage_container_type": "Azure",
+            "job_parameters": {},
+        },
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{BASE}/speech-to-text/job/v1/upload-files",
+        json={
+            "job_id": "job-1",
+            "job_state": "Accepted",
+            "storage_container_type": "Azure",
+            "upload_urls": {"meeting.wav": {"file_url": "https://blob.example/upload/meeting.wav"}},
+        },
+    )
+    httpx_mock.add_response(
+        method="PUT",
+        url="https://blob.example/upload/meeting.wav",
+        status_code=201,
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{BASE}/speech-to-text/job/v1/job-1/start",
+        json={"job_id": "job-1", "job_state": "Running"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{BASE}/speech-to-text/job/v1/job-1/status",
+        json={
+            "job_id": "job-1",
+            "job_state": "Completed",
+            "created_at": "2026-07-18T00:00:00Z",
+            "updated_at": "2026-07-18T00:01:00Z",
+            "storage_container_type": "Azure",
+            "total_files": 1,
+            "successful_files_count": 1,
+            "failed_files_count": 0,
+            "job_details": [
+                {
+                    "inputs": [{"file_name": "meeting.wav", "file_id": "file-1"}],
+                    "outputs": [{"file_name": "0.json", "file_id": "file-1-out"}],
+                    "state": "Success",
+                }
+            ],
+        },
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{BASE}/speech-to-text/job/v1/download-files",
+        json={
+            "job_id": "job-1",
+            "job_state": "Completed",
+            "storage_container_type": "Azure",
+            "download_urls": {"0.json": {"file_url": "https://blob.example/output/0.json"}},
+        },
+    )
+    output_body: dict[str, Any] = {
+        "request_id": "req-1",
+        "transcript": "Speaker 1: hello. Speaker 2: hi there.",
+        "language_code": "hi-IN",
+    }
+    if with_diarization:
+        output_body["diarized_transcript"] = {
+            "entries": [
+                {
+                    "transcript": "hello",
+                    "start_time_seconds": 0.0,
+                    "end_time_seconds": 1.0,
+                    "speaker_id": "0",
+                },
+                {
+                    "transcript": "hi there",
+                    "start_time_seconds": 1.2,
+                    "end_time_seconds": 2.5,
+                    "speaker_id": "1",
+                },
+            ]
+        }
+    httpx_mock.add_response(
+        method="GET",
+        url="https://blob.example/output/0.json",
+        json=output_body,
+    )
+
+
+async def test_batch_submit_downloads_and_returns_transcript(stt_server, httpx_mock, audio_file):
+    _mock_happy_path(httpx_mock)
+
+    async with Client(stt_server) as client:
+        result = await client.call_tool("sarvam_tools_stt_batch_submit", {"audio_path": str(audio_file)})
+
+    data = result.structured_content
+    assert data is not None
+    assert data["job_state"] == "Completed"
+    assert data["transcript"] == "Speaker 1: hello. Speaker 2: hi there."
+    assert data["language_code"] == "hi-IN"
+
+
+async def test_batch_submit_returns_diarized_entries(stt_server, httpx_mock, audio_file):
+    _mock_happy_path(httpx_mock, with_diarization=True)
+
+    async with Client(stt_server) as client:
+        result = await client.call_tool(
+            "sarvam_tools_stt_batch_submit",
+            {"audio_path": str(audio_file), "with_diarization": True, "num_speakers": 2},
+        )
+
+    data = result.structured_content
+    assert data is not None
+    entries = data["diarized_transcript"]["entries"]
+    assert [e["speaker_id"] for e in entries] == ["0", "1"]
+    assert entries[0]["transcript"] == "hello"
+
+
+async def test_batch_submit_with_no_successful_outputs_returns_empty_transcript(
+    stt_server, httpx_mock, audio_file
+):
+    # A job that completes with zero successful files should not attempt a
+    # download-files call at all, and must not error.
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{BASE}/speech-to-text/job/v1",
+        json={"job_id": "job-2", "job_state": "Accepted", "storage_container_type": "Azure"},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{BASE}/speech-to-text/job/v1/upload-files",
+        json={
+            "job_id": "job-2",
+            "job_state": "Accepted",
+            "storage_container_type": "Azure",
+            "upload_urls": {"meeting.wav": {"file_url": "https://blob.example/upload/meeting.wav"}},
+        },
+    )
+    httpx_mock.add_response(method="PUT", url="https://blob.example/upload/meeting.wav", status_code=201)
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{BASE}/speech-to-text/job/v1/job-2/start",
+        json={"job_id": "job-2", "job_state": "Running"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{BASE}/speech-to-text/job/v1/job-2/status",
+        json={
+            "job_id": "job-2",
+            "job_state": "Failed",
+            "created_at": "2026-07-18T00:00:00Z",
+            "updated_at": "2026-07-18T00:01:00Z",
+            "storage_container_type": "Azure",
+            "total_files": 1,
+            "successful_files_count": 0,
+            "failed_files_count": 1,
+            "job_details": [
+                {
+                    "inputs": [{"file_name": "meeting.wav", "file_id": "file-1"}],
+                    "outputs": [],
+                    "state": "API Error",
+                    "error_message": "decode failure",
+                }
+            ],
+        },
+    )
+
+    async with Client(stt_server) as client:
+        result = await client.call_tool("sarvam_tools_stt_batch_submit", {"audio_path": str(audio_file)})
+
+    data = result.structured_content
+    assert data is not None
+    assert data["job_state"] == "Failed"
+    assert data["transcript"] == ""


### PR DESCRIPTION
## Summary

`sarvam_tools_stt_batch_submit` polls `GET /status` until the job reaches
`Completed`, then reads the transcript straight off that response
(`result`, `transcript`, `download_urls`). Per the live API spec
(docs.sarvam.ai), `/status` never returns any of those fields — only job
progress and `job_details[].outputs[].file_name`. The transcript is only
reachable via a separate call: `POST /speech-to-text/job/v1/download-files`
with those filenames, which returns a signed URL to the actual output JSON.

As a result, every completed batch job silently returns `transcript: ""`
— no exception, no error, `job_state: "Completed"`. This is the only STT
path that supports diarization (the sync `/speech-to-text` endpoint
doesn't), so every speaker-labelled transcription request has been
affected since this tool shipped.

## Root cause

```python
# src/sarvam_mcp/tools/stt.py — sarvam_stt_batch_submit, Step 6 (before)
result = status_resp.get("result") or {}
transcript = result.get("transcript") or status_resp.get("transcript")

if not transcript:
    download_urls = status_resp.get("download_urls", {})   # ❌ never present on /status
    if download_urls:
        ...
```

`STT_JOB_DOWNLOAD` (`f"{STT_JOB_BASE}/download-files"`) is defined as a
constant but is never called anywhere in the file — nothing ever POSTs to
it, so `download_urls` is always `{}` and the fallback branch never runs.

## Fix

```python
# after
output_files: list[str] = []
for task in status_resp.get("job_details", []):
    if task.get("state") == "Success":
        for out in task.get("outputs", []):
            output_files.append(out["file_name"])

if output_files:
    download_resp, call = await sc.client.post_json(
        STT_JOB_DOWNLOAD, json_body={"job_id": job_id, "files": output_files},
    )
    metrics.merge(call)
    download_urls = download_resp.get("download_urls", {})
    if download_urls:
        dl_url = next(iter(download_urls.values()))["file_url"]
        async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as dl:
            dl_resp = await dl.get(dl_url)
        if dl_resp.is_success:
            result = dl_resp.json()
```

## Tests

New `tests/tools/test_stt.py` mocks the full job lifecycle — create,
upload, start, status, **download-files**, and the signed-URL fetch.

Before this fix (`main`):
```
tests/tools/test_stt.py::test_batch_submit_downloads_and_returns_transcript FAILED
tests/tools/test_stt.py::test_batch_submit_returns_diarized_entries FAILED
tests/tools/test_stt.py::test_batch_submit_with_no_successful_outputs_returns_empty_transcript PASSED
2 failed, 1 passed
```

After this fix:
```
tests/tools/test_stt.py::test_batch_submit_downloads_and_returns_transcript PASSED
tests/tools/test_stt.py::test_batch_submit_returns_diarized_entries PASSED
tests/tools/test_stt.py::test_batch_submit_with_no_successful_outputs_returns_empty_transcript PASSED
3 passed
```

Full suite: `pytest -q` → 64 passed. `ruff check` clean.

### Live verification against the real API (not mocked)

Reproduced the bug against `main` first, against the real Sarvam API, using
a real synthesized 45s two-speaker audio clip (`with_diarization=true`):

```
job_state:           "Completed"
transcript:           ""
diarized_transcript:  null
observability.upstream_calls: 6   # create, upload-files, blob PUT, start, status x2 — no download-files
```

Then ran the identical audio file through this fix, same tool, same
parameters:

```
job_state:  "Completed"
transcript: "Hey, thanks for joining the call. Let's do a quick sync on
the sprint progress before we wrap up for the day. Sure, happy to jump
in. On my end, the payment integration is mostly done, just waiting on a
code review before merging. ..." (full 7-turn transcript, ~130 words)

diarized_transcript.entries: 7 turns, correctly alternating between two
speaker_ids with accurate start/end timestamps summing to the full 45s,
e.g.:
  [speaker_id="1"] 0.01–6.25s   "Hey, thanks for joining the call..."
  [speaker_id="2"] 6.89–15.67s  "Sure, happy to jump in..."
  [speaker_id="1"] 16.17–22.11s "That's great progress..."
  ...
```

## Scope / risk

- Touches only `src/sarvam_mcp/tools/stt.py` (Step 6 of
  `sarvam_stt_batch_submit`) and the new test file.
- No change to the create/upload/start/poll steps, the sync transcribe
  tool, or the translate tool.
- `output_files` defaults to `[]` when no task succeeded, so a fully
  failed job still returns `transcript: ""` safely rather than erroring.