### PR TITLE
feat: add sv_meet meeting transcription and summarization workflow

### DIFF
--- a/src/sarvam_mcp/server.py
+++ b/src/sarvam_mcp/server.py
@@ -134,6 +134,7 @@ def build_server() -> FastMCP:
     workflows.dub.register(mcp)
     workflows.localize.register(mcp)
     workflows.recall.register(mcp)
+    workflows.meet.register(mcp)
 
     return mcp
 

--- a/src/sarvam_mcp/tools/stt.py
+++ b/src/sarvam_mcp/tools/stt.py
@@ -10,7 +10,8 @@ import httpx
 from fastmcp import Context, FastMCP
 from pydantic import Field
 
-from sarvam_mcp.observability import measure_tool
+from sarvam_mcp._registry import ServerContext
+from sarvam_mcp.observability import ToolMetrics, measure_tool
 from sarvam_mcp.tools._common import LanguageCode, ready_ctx, resolve_file_input
 
 STT_PATH = "/speech-to-text"
@@ -30,6 +31,137 @@ InputAudioCodec = Literal["pcm_s16le", "pcm_l16", "pcm_raw"]
 
 # Legacy model types kept for the deprecated translate tool.
 SaarasModel = Literal["saaras:v3", "saaras:v3-realtime", "saaras:v2.5"]
+
+
+async def stt_batch_transcribe(
+    sc: ServerContext,
+    ctx: Context,
+    audio_path: Path,
+    *,
+    language_code: str = "unknown",
+    mode: str = "transcribe",
+    with_timestamps: bool = False,
+    with_diarization: bool = False,
+    num_speakers: int | None = None,
+    model: str = "saaras:v3",
+    metrics: ToolMetrics | None = None,
+) -> dict[str, Any]:
+    """Run the full batch STT flow: create job → upload → start → poll → extract.
+
+    Chains the five manual steps (create, register upload, PUT to blob, start,
+    poll-until-terminal) that ``sarvam_tools_stt_batch_submit`` exposes as one
+    tool call. Shared here so other composite workflows (e.g. ``sv_meet``) can
+    reuse batch/diarized transcription without re-implementing the polling loop.
+
+    Returns a dict shaped like the tool response, minus ``observability`` —
+    callers merge that in from their own ``metrics`` after their
+    ``measure_tool()`` block exits. On a poll timeout the dict has only
+    ``job_id`` / ``job_state`` / ``error`` — no transcript fields.
+    """
+    if metrics is None:
+        metrics = ToolMetrics(latency_ms=0.0)
+
+    # Step 1: Create the job
+    await ctx.info("Creating batch STT job…")
+    job_params: dict[str, Any] = {
+        "language_code": language_code if language_code != "unknown" else None,
+        "model": model,
+        "mode": mode,
+        "with_timestamps": with_timestamps,
+        "with_diarization": with_diarization,
+    }
+    if num_speakers is not None:
+        job_params["num_speakers"] = num_speakers
+    job_params = {k: v for k, v in job_params.items() if v is not None}
+
+    create_resp, call = await sc.client.post_json(STT_JOB_BASE, json_body={"job_parameters": job_params})
+    metrics.merge(call)
+    job_id = create_resp["job_id"]
+
+    # Step 2: Register files → get upload SAS URLs
+    await ctx.info(f"Registering audio file for job {job_id}…")
+    upload_resp, call = await sc.client.post_json(
+        STT_JOB_UPLOAD,
+        json_body={"job_id": job_id, "files": [audio_path.name]},
+    )
+    metrics.merge(call)
+
+    upload_urls = upload_resp.get("upload_urls", {})
+    if not upload_urls:
+        raise RuntimeError(f"No upload URLs returned for job {job_id}")
+
+    # Step 3: PUT audio bytes to Azure Blob
+    await ctx.info("Uploading audio to Azure Blob…")
+    file_details = next(iter(upload_urls.values()))
+    presigned_url = file_details["file_url"]
+    file_metadata = file_details.get("file_metadata") or {}
+
+    extra_headers = {str(k): str(v) for k, v in file_metadata.items()}
+    with audio_path.open("rb") as fh:
+        blob_metrics = await sc.client.put_blob(
+            presigned_url,
+            fh.read(),
+            content_type=_guess_audio_mime(audio_path),
+            extra_headers=extra_headers,
+        )
+    metrics.merge(blob_metrics)
+
+    # Step 4: Start the job
+    await ctx.info("Starting batch processing…")
+    start_resp, call = await sc.client.post_json(
+        f"{STT_JOB_BASE}/{job_id}/start",
+        json_body={"job_id": job_id, "job_parameters": job_params},
+    )
+    metrics.merge(call)
+
+    # Step 5: Poll for completion
+    await ctx.info("Polling for completion…")
+    terminal_states = {"Completed", "PartiallyCompleted", "Failed", "failed", "error"}
+    status_resp: dict[str, Any] = {}
+    for attempt in range(MAX_POLL_ATTEMPTS):
+        status_resp, call = await sc.client.get_json(f"{STT_JOB_BASE}/{job_id}/status")
+        metrics.merge(call)
+        job_state = status_resp.get("job_state", "")
+        if job_state in terminal_states:
+            break
+        if (attempt + 1) % 5 == 0:
+            await ctx.report_progress(attempt + 1, MAX_POLL_ATTEMPTS)
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+    else:
+        return {
+            "job_id": job_id,
+            "job_state": status_resp.get("job_state", "timeout"),
+            "error": (
+                f"Job did not complete within "
+                f"{MAX_POLL_ATTEMPTS * POLL_INTERVAL_SECONDS}s. "
+                f"Poll manually with sarvam_tools_stt_batch_status."
+            ),
+        }
+
+    # Step 6: Extract transcript
+    result = status_resp.get("result") or {}
+    transcript = result.get("transcript") or status_resp.get("transcript")
+
+    if not transcript:
+        download_urls = status_resp.get("download_urls", {})
+        if download_urls:
+            await ctx.info("Downloading transcript…")
+            dl_url = next(iter(download_urls.values()))["file_url"]
+            async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as dl:
+                dl_resp = await dl.get(dl_url)
+            if dl_resp.is_success:
+                dl_body = dl_resp.json()
+                transcript = dl_body.get("transcript", "")
+                result = dl_body
+
+    return {
+        "job_id": job_id,
+        "job_state": status_resp.get("job_state"),
+        "transcript": transcript or "",
+        "language_code": result.get("language_code"),
+        "diarized_transcript": result.get("diarized_transcript"),
+        "timestamps": result.get("timestamps"),
+    }
 
 
 def register(mcp: FastMCP) -> None:
@@ -236,113 +368,20 @@ def register(mcp: FastMCP) -> None:
             file_url=audio_url, filename=filename,
         ) as path:
             with measure_tool() as metrics:
-                # Step 1: Create the job
-                await ctx.info("Creating batch STT job…")
-                job_params: dict[str, Any] = {
-                    "language_code": language_code if language_code != "unknown" else None,
-                    "model": model,
-                    "mode": mode,
-                    "with_timestamps": with_timestamps,
-                    "with_diarization": with_diarization,
-                }
-                if num_speakers is not None:
-                    job_params["num_speakers"] = num_speakers
-                job_params = {k: v for k, v in job_params.items() if v is not None}
-
-                create_resp, call = await sc.client.post_json(
-                    STT_JOB_BASE, json_body={"job_parameters": job_params}
+                result = await stt_batch_transcribe(
+                    sc,
+                    ctx,
+                    path,
+                    language_code=language_code,
+                    mode=mode,
+                    with_timestamps=with_timestamps,
+                    with_diarization=with_diarization,
+                    num_speakers=num_speakers,
+                    model=model,
+                    metrics=metrics,
                 )
-                metrics.merge(call)
-                job_id = create_resp["job_id"]
 
-                # Step 2: Register files → get upload SAS URLs
-                await ctx.info(f"Registering audio file for job {job_id}…")
-                upload_resp, call = await sc.client.post_json(
-                    STT_JOB_UPLOAD,
-                    json_body={"job_id": job_id, "files": [path.name]},
-                )
-                metrics.merge(call)
-
-                upload_urls = upload_resp.get("upload_urls", {})
-                if not upload_urls:
-                    raise RuntimeError(f"No upload URLs returned for job {job_id}")
-
-                # Step 3: PUT audio bytes to Azure Blob
-                await ctx.info("Uploading audio to Azure Blob…")
-                file_details = next(iter(upload_urls.values()))
-                presigned_url = file_details["file_url"]
-                file_metadata = file_details.get("file_metadata") or {}
-
-                extra_headers = {str(k): str(v) for k, v in file_metadata.items()}
-                with path.open("rb") as fh:
-                    blob_metrics = await sc.client.put_blob(
-                        presigned_url,
-                        fh.read(),
-                        content_type=_guess_audio_mime(path),
-                        extra_headers=extra_headers,
-                    )
-                metrics.merge(blob_metrics)
-
-                # Step 4: Start the job
-                await ctx.info("Starting batch processing…")
-                start_resp, call = await sc.client.post_json(
-                    f"{STT_JOB_BASE}/{job_id}/start",
-                    json_body={"job_id": job_id, "job_parameters": job_params},
-                )
-                metrics.merge(call)
-
-                # Step 5: Poll for completion
-                await ctx.info("Polling for completion…")
-                terminal_states = {"Completed", "PartiallyCompleted", "Failed", "failed", "error"}
-                status_resp: dict[str, Any] = {}
-                for attempt in range(MAX_POLL_ATTEMPTS):
-                    status_resp, call = await sc.client.get_json(
-                        f"{STT_JOB_BASE}/{job_id}/status"
-                    )
-                    metrics.merge(call)
-                    job_state = status_resp.get("job_state", "")
-                    if job_state in terminal_states:
-                        break
-                    if (attempt + 1) % 5 == 0:
-                        await ctx.report_progress(attempt + 1, MAX_POLL_ATTEMPTS)
-                    await asyncio.sleep(POLL_INTERVAL_SECONDS)
-                else:
-                    return {
-                        "job_id": job_id,
-                        "job_state": status_resp.get("job_state", "timeout"),
-                        "error": (
-                            f"Job did not complete within "
-                            f"{MAX_POLL_ATTEMPTS * POLL_INTERVAL_SECONDS}s. "
-                            f"Poll manually with sarvam_tools_stt_batch_status."
-                        ),
-                        "observability": metrics.to_response_block(),
-                    }
-
-                # Step 6: Extract transcript
-                result = status_resp.get("result") or {}
-                transcript = result.get("transcript") or status_resp.get("transcript")
-
-                if not transcript:
-                    download_urls = status_resp.get("download_urls", {})
-                    if download_urls:
-                        await ctx.info("Downloading transcript…")
-                        dl_url = next(iter(download_urls.values()))["file_url"]
-                        async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as dl:
-                            dl_resp = await dl.get(dl_url)
-                        if dl_resp.is_success:
-                            dl_body = dl_resp.json()
-                            transcript = dl_body.get("transcript", "")
-                            result = dl_body
-
-        return {
-            "job_id": job_id,
-            "job_state": status_resp.get("job_state"),
-            "transcript": transcript or "",
-            "language_code": result.get("language_code"),
-            "diarized_transcript": result.get("diarized_transcript"),
-            "timestamps": result.get("timestamps"),
-            "observability": metrics.to_response_block(),
-        }
+        return {**result, "observability": metrics.to_response_block()}
 
     @mcp.tool(
         name="sarvam_tools_stt_batch_status",

--- a/src/sarvam_mcp/tools/stt.py
+++ b/src/sarvam_mcp/tools/stt.py
@@ -11,6 +11,7 @@ from fastmcp import Context, FastMCP
 from pydantic import Field
 
 from sarvam_mcp._registry import ServerContext
+from sarvam_mcp.http.errors import SarvamBadRequestError
 from sarvam_mcp.observability import ToolMetrics, measure_tool
 from sarvam_mcp.tools._common import LanguageCode, ready_ctx, resolve_file_input
 
@@ -22,6 +23,12 @@ STT_JOB_DOWNLOAD = f"{STT_JOB_BASE}/download-files"
 
 MAX_POLL_ATTEMPTS = 90
 POLL_INTERVAL_SECONDS = 2
+
+# /download-files can reject a job as not-yet-Completed for a few seconds
+# right after /status already reports it terminal — a backend consistency
+# lag between the two endpoints, observed most on fast-completing jobs.
+DOWNLOAD_READY_ATTEMPTS = 3
+DOWNLOAD_READY_RETRY_DELAY_SECONDS = 3
 
 SttModel = Literal["saaras:v3"]
 
@@ -143,16 +150,33 @@ async def stt_batch_transcribe(
     transcript = result.get("transcript") or status_resp.get("transcript")
 
     if not transcript:
-        download_urls = status_resp.get("download_urls", {})
-        if download_urls:
+        # The status response never inlines the result for a job whose output
+        # wasn't returned directly — the documented flow is to fetch the SAS
+        # URL for each output file via /download-files, then GET it.
+        file_names = [
+            output["file_name"]
+            for detail in status_resp.get("job_details") or []
+            for output in detail.get("outputs") or []
+            if output.get("file_name")
+        ]
+        if file_names:
+            await ctx.info("Fetching output file list…")
+            download_urls = await _fetch_download_urls(sc, job_id, file_names, metrics)
+
             await ctx.info("Downloading transcript…")
-            dl_url = next(iter(download_urls.values()))["file_url"]
             async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as dl:
-                dl_resp = await dl.get(dl_url)
-            if dl_resp.is_success:
-                dl_body = dl_resp.json()
-                transcript = dl_body.get("transcript", "")
-                result = dl_body
+                for file_details in download_urls.values():
+                    dl_url = file_details.get("file_url")
+                    if not dl_url:
+                        continue
+                    dl_resp = await dl.get(dl_url)
+                    if not dl_resp.is_success:
+                        continue
+                    dl_body = dl_resp.json()
+                    if dl_body.get("transcript"):
+                        transcript = dl_body["transcript"]
+                        result = dl_body
+                        break
 
     return {
         "job_id": job_id,
@@ -162,6 +186,39 @@ async def stt_batch_transcribe(
         "diarized_transcript": result.get("diarized_transcript"),
         "timestamps": result.get("timestamps"),
     }
+
+
+async def _fetch_download_urls(
+    sc: ServerContext,
+    job_id: str,
+    file_names: list[str],
+    metrics: ToolMetrics,
+) -> dict[str, Any]:
+    """POST /download-files, retrying briefly on a transient consistency lag.
+
+    Observed live: /download-files can reject a job as not-yet-Completed for
+    a few seconds right after /status already reports it terminal, most often
+    on fast-completing jobs. Retries only on that specific rejection — any
+    other SarvamBadRequestError (a real caller-side problem) is not retried.
+    """
+    for attempt in range(DOWNLOAD_READY_ATTEMPTS):
+        try:
+            dl_list_resp, call = await sc.client.post_json(
+                STT_JOB_DOWNLOAD,
+                json_body={"job_id": job_id, "files": file_names},
+            )
+        except SarvamBadRequestError as exc:
+            if "COMPLETED state" not in str(exc) or attempt == DOWNLOAD_READY_ATTEMPTS - 1:
+                raise RuntimeError(
+                    f"Job {job_id} polled as terminal, but /download-files still "
+                    f"rejects it after {attempt + 1} attempt(s): {exc}"
+                ) from exc
+            await asyncio.sleep(DOWNLOAD_READY_RETRY_DELAY_SECONDS * (attempt + 1))
+            continue
+        metrics.merge(call)
+        return dl_list_resp.get("download_urls") or {}
+
+    raise AssertionError("unreachable")  # loop always returns or raises
 
 
 def register(mcp: FastMCP) -> None:

--- a/src/sarvam_mcp/workflows/__init__.py
+++ b/src/sarvam_mcp/workflows/__init__.py
@@ -9,6 +9,6 @@ the atomic tools so any naming clash falls in favor of the explicit
 ``sarvam_*`` ones.
 """
 
-from sarvam_mcp.workflows import dub, localize, recall, voice
+from sarvam_mcp.workflows import dub, localize, meet, recall, voice
 
-__all__ = ["dub", "localize", "recall", "voice"]
+__all__ = ["dub", "localize", "meet", "recall", "voice"]

--- a/src/sarvam_mcp/workflows/meet.py
+++ b/src/sarvam_mcp/workflows/meet.py
@@ -1,0 +1,181 @@
+"""``sv_meet`` — meeting transcription, diarization, and summarisation.
+
+Batch-transcribes a long audio recording with speaker diarization, then asks
+the LLM to turn the speaker-labelled transcript into a summary, action items,
+and decisions. Composes ``stt_batch_transcribe`` (tools/stt.py) and
+``llm_complete`` (workflows/_helpers.py) — no new API dependency.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastmcp import Context, FastMCP
+from pydantic import Field
+
+from sarvam_mcp.observability import measure_tool
+from sarvam_mcp.tools._common import LanguageCode, SarvamLLM, ready_ctx, resolve_file_input
+from sarvam_mcp.tools.stt import stt_batch_transcribe
+from sarvam_mcp.workflows._helpers import llm_complete
+
+_SYSTEM_PROMPT = (
+    "You produce structured meeting minutes from a speaker-labelled transcript. "
+    "Reply with ONLY a JSON object — no prose, no markdown code fences — matching "
+    'exactly this shape: {"summary": str, "action_items": [str], "decisions": [str]}. '
+    "summary is a short paragraph. action_items are concrete follow-ups, phrased as "
+    "tasks. decisions are choices the group settled on. Use an empty list if there are none."
+)
+
+
+def register(mcp: FastMCP) -> None:
+    @mcp.tool(
+        name="sarvam_tools_meet",
+        description=(
+            "Runtime tool — calls Sarvam API now. For code-writing help, use sarvam_code_* tools.\n\n"
+            "Meeting transcription workflow: batch-transcribes a long audio recording "
+            "with speaker diarization, then asks the LLM for a summary, action items, "
+            "and decisions.\n\n"
+            "Returns: speaker-labelled transcript, raw diarized turns, summary, "
+            "action items, decisions. For files under ~30s or when diarization "
+            "isn't needed, use sarvam_tools_stt_transcribe instead."
+        ),
+    )
+    async def sv_meet(
+        ctx: Context,
+        audio_path: str | None = Field(default=None, description="Local path to the input audio file."),
+        audio_base64: str | None = Field(default=None, description="Base64-encoded audio data."),
+        audio_url: str | None = Field(default=None, description="URL to fetch the audio file from."),
+        filename: str | None = Field(default=None, description="Filename with extension (for base64/URL)."),
+        language_code: LanguageCode = Field(
+            default="unknown",
+            description="STT hint. 'unknown' enables language auto-detect.",
+        ),
+        num_speakers: int | None = Field(
+            default=None,
+            description="Hint for diarization: expected number of speakers.",
+        ),
+        llm_model: SarvamLLM = Field(
+            default="sarvam-30b",
+            description="`sarvam-30b` (default) or `sarvam-105b` (flagship).",
+        ),
+    ) -> dict[str, Any]:
+        sc = await ready_ctx(ctx)
+        async with resolve_file_input(
+            file_path=audio_path, file_base64=audio_base64,
+            file_url=audio_url, filename=filename,
+        ) as path:
+            with measure_tool() as metrics:
+                await ctx.info("Transcribing meeting audio with diarization…")
+                batch_result = await stt_batch_transcribe(
+                    sc,
+                    ctx,
+                    path,
+                    language_code=language_code,
+                    with_diarization=True,
+                    num_speakers=num_speakers,
+                    metrics=metrics,
+                )
+
+                if "error" in batch_result:
+                    return {**batch_result, "observability": metrics.to_response_block()}
+
+                transcript_text, turns = _render_diarized_transcript(
+                    batch_result.get("diarized_transcript"),
+                    batch_result.get("transcript", ""),
+                )
+                if not transcript_text.strip():
+                    raise RuntimeError(
+                        "Batch STT completed but returned an empty transcript — nothing to summarize."
+                    )
+
+                await ctx.info("Summarizing transcript…")
+                llm_reply = await llm_complete(
+                    sc,
+                    [
+                        {"role": "system", "content": _SYSTEM_PROMPT},
+                        {"role": "user", "content": transcript_text},
+                    ],
+                    model=llm_model,
+                    temperature=0.1,
+                    max_tokens=1200,
+                    metrics=metrics,
+                )
+                parsed = _parse_meeting_summary(llm_reply)
+
+        return {
+            "job_id": batch_result.get("job_id"),
+            "job_state": batch_result.get("job_state"),
+            "transcript": transcript_text,
+            "diarized_turns": turns,
+            "language_code": batch_result.get("language_code"),
+            **parsed,
+            "observability": metrics.to_response_block(),
+        }
+
+
+def _render_diarized_transcript(
+    diarized_transcript: dict[str, Any] | None,
+    fallback_transcript: str,
+) -> tuple[str, list[dict[str, Any]]]:
+    """Render diarized entries into a speaker-labelled transcript string.
+
+    ``diarized_transcript`` is ``{"entries": [{"transcript", "start_time_seconds",
+    "end_time_seconds", "speaker_id"}, ...]}`` per the Sarvam batch STT API.
+    Falls back to the plain transcript, unlabelled, when diarization isn't
+    present — it isn't guaranteed even with ``with_diarization=True`` (e.g.
+    very short or single-speaker audio).
+    """
+    entries = (diarized_transcript or {}).get("entries") or []
+    if not entries:
+        return fallback_transcript, []
+
+    lines: list[str] = []
+    for entry in entries:
+        speaker = f"Speaker {entry.get('speaker_id', '?')}"
+        text = entry.get("transcript", "")
+        start = entry.get("start_time_seconds")
+        end = entry.get("end_time_seconds")
+        if start is not None and end is not None:
+            lines.append(f"[{start:.1f}s–{end:.1f}s] {speaker}: {text}")
+        else:
+            lines.append(f"{speaker}: {text}")
+    return "\n".join(lines), entries
+
+
+def _parse_meeting_summary(raw: str) -> dict[str, Any]:
+    """Parse the LLM's JSON reply into summary/action_items/decisions.
+
+    Strips a leading/trailing markdown code fence if present (models often
+    add one despite instructions not to), then ``json.loads()``. Degrades to
+    a ``parse_warning`` shape on any failure — including valid-but-non-dict
+    JSON — rather than silently returning empty lists as if they were real
+    output.
+    """
+    text = raw.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1] if "\n" in text else text
+        if text.endswith("```"):
+            text = text[:-3]
+        if text.startswith("json"):
+            text = text[4:]
+        text = text.strip()
+
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+
+    if not isinstance(parsed, dict):
+        return {
+            "summary": raw,
+            "action_items": [],
+            "decisions": [],
+            "parse_warning": "LLM did not return a valid JSON object; summary is the raw model output.",
+        }
+
+    return {
+        "summary": parsed.get("summary", raw),
+        "action_items": parsed.get("action_items") or [],
+        "decisions": parsed.get("decisions") or [],
+    }

--- a/tests/tools/test_registration.py
+++ b/tests/tools/test_registration.py
@@ -27,6 +27,7 @@ EXPECTED_TOOLS = {
     "sarvam_tools_dub",
     "sarvam_tools_localize",
     "sarvam_tools_recall",
+    "sarvam_tools_meet",
 }
 
 

--- a/tests/tools/test_stt.py
+++ b/tests/tools/test_stt.py
@@ -1,0 +1,65 @@
+"""Unit tests for the /download-files consistency-lag retry in stt_batch_transcribe."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sarvam_mcp.http.errors import SarvamBadRequestError
+from sarvam_mcp.observability import CallMetrics, ToolMetrics
+from sarvam_mcp.tools.stt import _fetch_download_urls
+
+
+class _FakeClient:
+    def __init__(self, post_json):
+        self.post_json = post_json
+
+
+class _FakeServerContext:
+    def __init__(self, post_json):
+        self.client = _FakeClient(post_json)
+
+
+async def test_retries_once_on_not_yet_completed_then_succeeds(monkeypatch):
+    monkeypatch.setattr("sarvam_mcp.tools.stt.asyncio.sleep", AsyncMock())
+
+    not_ready = SarvamBadRequestError("Job abc123 is not in COMPLETED state. Current state: Pending")
+    success_body = {"download_urls": {"0.json": {"file_url": "https://example.com/0.json"}}}
+    post_json = AsyncMock(side_effect=[not_ready, (success_body, CallMetrics(request_id="r1"))])
+    sc = _FakeServerContext(post_json)
+    metrics = ToolMetrics(latency_ms=0.0)
+
+    result = await _fetch_download_urls(sc, "abc123", ["0.json"], metrics)
+
+    assert result == success_body["download_urls"]
+    assert post_json.call_count == 2
+    assert metrics.request_ids == ["r1"]
+
+
+async def test_gives_up_after_max_attempts_with_clear_error(monkeypatch):
+    monkeypatch.setattr("sarvam_mcp.tools.stt.asyncio.sleep", AsyncMock())
+
+    always_not_ready = SarvamBadRequestError("Job abc123 is not in COMPLETED state. Current state: Pending")
+    post_json = AsyncMock(side_effect=always_not_ready)
+    sc = _FakeServerContext(post_json)
+    metrics = ToolMetrics(latency_ms=0.0)
+
+    with pytest.raises(RuntimeError, match="abc123"):
+        await _fetch_download_urls(sc, "abc123", ["0.json"], metrics)
+
+    assert post_json.call_count == 3  # DOWNLOAD_READY_ATTEMPTS
+
+
+async def test_does_not_retry_a_different_bad_request_error(monkeypatch):
+    monkeypatch.setattr("sarvam_mcp.tools.stt.asyncio.sleep", AsyncMock())
+
+    unrelated_error = SarvamBadRequestError("job_id is required")
+    post_json = AsyncMock(side_effect=unrelated_error)
+    sc = _FakeServerContext(post_json)
+    metrics = ToolMetrics(latency_ms=0.0)
+
+    with pytest.raises(RuntimeError):
+        await _fetch_download_urls(sc, "abc123", ["0.json"], metrics)
+
+    assert post_json.call_count == 1

--- a/tests/workflows/test_meet.py
+++ b/tests/workflows/test_meet.py
@@ -1,0 +1,79 @@
+"""Pure-logic helpers for ``sv_meet``: transcript rendering and summary parsing."""
+
+from __future__ import annotations
+
+from sarvam_mcp.workflows.meet import _parse_meeting_summary, _render_diarized_transcript
+
+
+def test_render_falls_back_to_plain_transcript_when_entries_missing():
+    text, turns = _render_diarized_transcript(None, "plain fallback transcript")
+    assert text == "plain fallback transcript"
+    assert turns == []
+
+
+def test_render_falls_back_to_plain_transcript_when_entries_empty():
+    text, turns = _render_diarized_transcript({"entries": []}, "plain fallback transcript")
+    assert text == "plain fallback transcript"
+    assert turns == []
+
+
+def test_render_multi_speaker_with_timestamps():
+    diarized = {
+        "entries": [
+            {
+                "transcript": "Hello, how can I help you today?",
+                "start_time_seconds": 0.01,
+                "end_time_seconds": 2.5,
+                "speaker_id": "0",
+            },
+            {
+                "transcript": "I have a question.",
+                "start_time_seconds": 2.8,
+                "end_time_seconds": 4.2,
+                "speaker_id": "1",
+            },
+        ]
+    }
+    text, turns = _render_diarized_transcript(diarized, "unused fallback")
+    assert text == (
+        "[0.0s–2.5s] Speaker 0: Hello, how can I help you today?\n[2.8s–4.2s] Speaker 1: I have a question."
+    )
+    assert turns == diarized["entries"]
+
+
+def test_parse_valid_json():
+    raw = (
+        '{"summary": "Team agreed on the launch date.", '
+        '"action_items": ["Ship by Friday"], '
+        '"decisions": ["Launch on Friday"]}'
+    )
+    parsed = _parse_meeting_summary(raw)
+    assert parsed == {
+        "summary": "Team agreed on the launch date.",
+        "action_items": ["Ship by Friday"],
+        "decisions": ["Launch on Friday"],
+    }
+
+
+def test_parse_json_wrapped_in_code_fence():
+    raw = '```json\n{"summary": "Short recap.", "action_items": [], "decisions": []}\n```'
+    parsed = _parse_meeting_summary(raw)
+    assert parsed == {"summary": "Short recap.", "action_items": [], "decisions": []}
+
+
+def test_parse_malformed_json_falls_back_to_parse_warning():
+    raw = "Sure, here's the summary: the team discussed the roadmap."
+    parsed = _parse_meeting_summary(raw)
+    assert parsed["summary"] == raw
+    assert parsed["action_items"] == []
+    assert parsed["decisions"] == []
+    assert "parse_warning" in parsed
+
+
+def test_parse_valid_but_non_dict_json_falls_back_to_parse_warning():
+    raw = '["summary text", "not", "a", "dict"]'
+    parsed = _parse_meeting_summary(raw)
+    assert parsed["summary"] == raw
+    assert parsed["action_items"] == []
+    assert parsed["decisions"] == []
+    assert "parse_warning" in parsed


### PR DESCRIPTION
## Summary

Adds `sv_meet` (`sarvam_tools_meet`): batch-transcribes a long audio recording with speaker diarization, then asks the LLM to turn the speaker-labelled transcript into a summary, action items, and decisions.

Closes #39.

## Why

The four current workflows (`sv_voice`, `sv_dub`, `sv_localize`, `sv_recall`) cover audio loops, dubbing, i18n, and Q&A. None of them cover meetings: multi-speaker turns that need to become a summary, action items, and decisions. Getting speaker-labelled output today means manually chaining `sarvam_tools_stt_batch_submit`, polling, parsing `diarized_transcript`, writing a prompt by hand, and parsing the reply. This issue asked for that to be one tool call.

## Composition, not a new API dependency

`tools/stt.py`'s batch-submit-and-poll flow (create job, upload, start, poll, extract) was a closure nested inside the `sarvam_stt_batch_submit` tool, so nothing else could reuse it. I extracted it into a top-level `stt_batch_transcribe()` function in the same file; `sarvam_stt_batch_submit` now calls it. Behavior is unchanged: same steps, same `ctx.info`/`report_progress` calls, same response shape, all existing tests pass unmodified.

`sv_meet` is built on `stt_batch_transcribe()` and the existing `llm_complete()` helper in `workflows/_helpers.py`. No new Sarvam endpoint is called.

## Found and fixed during live testing

Testing `sv_meet` against a real recording surfaced a bug in the code I'd just extracted: when a completed job's transcript isn't inlined in the status response, the fallback that's supposed to retrieve it checked a `download_urls` field the status endpoint never actually returns. The documented flow requires a separate call to `/speech-to-text/job/v1/download-files` with the job's `job_id` and the output `file_name`s from `job_details[].outputs[]`, which nothing in the codebase called. Filed as #62 with the raw evidence, since it predates this PR and affects `sarvam_stt_batch_submit` directly, not just `sv_meet`.

Fixed here rather than left open, since `sv_meet`'s main path depended on it. `stt_batch_transcribe()` now collects the output file names, calls `/download-files`, and fetches each returned URL, handling zero or multiple output files rather than assuming exactly one.

That fix surfaced a second, smaller issue: `/download-files` can reject a job as not-yet-Completed for a few seconds right after `/status` already reports it terminal, a consistency lag between the two endpoints on Sarvam's side, most noticeable on fast-completing jobs. I hit it twice testing live. `_fetch_download_urls()` now retries that specific rejection a few times with a short backoff before giving up with a clear error; any other `SarvamBadRequestError` is not retried, so a real caller-side problem still surfaces immediately instead of being masked.

## Design notes

The real shape of `diarized_transcript` is `{"entries": [{"transcript", "start_time_seconds", "end_time_seconds", "speaker_id"}, ...]}`, confirmed against the batch STT docs. The output shape sketched in the issue (`speaker`/`text`/`start`/`end`) doesn't match the actual API, so the renderer and the `diarized_turns` field in the response use the real field names instead.

`llm_complete()` has no `response_format` parameter, and the documented `/v1/chat/completions` request body doesn't expose one either, so `sv_meet` prompts for JSON directly and parses defensively: it strips a markdown code fence if the model adds one, calls `json.loads()`, and falls back to a `parse_warning` shape (raw text as `summary`, empty `action_items`/`decisions`) for anything that isn't a valid JSON object, including valid JSON that isn't a dict.

Poll timeout and an empty transcript after a completed job are handled differently on purpose. A timeout returns the existing bare `{job_id, job_state, error}` dict, unchanged from `sarvam_stt_batch_submit`'s original behavior. An empty transcript after the job actually completes raises `RuntimeError`, matching `sv_voice`'s existing precedent for "technically succeeded, nothing usable to continue with."

There's no Pydantic output model and no correlation ID or trace field anywhere in this codebase, so `sv_meet` doesn't introduce one either. It returns a plain dict like every other workflow and relies on `job_id` plus `observability.request_ids` for tracing, same as the rest.

## Files changed

`src/sarvam_mcp/tools/stt.py` extracts `stt_batch_transcribe()` out of the `sarvam_stt_batch_submit` closure into a reusable top-level function, fixes the transcript-retrieval gap described above, and adds the `_fetch_download_urls()` retry helper.

`src/sarvam_mcp/workflows/meet.py` is new: the `sv_meet` tool, `_render_diarized_transcript()`, and `_parse_meeting_summary()`.

`src/sarvam_mcp/workflows/__init__.py` registers `meet` alphabetically, matching the existing order.

`src/sarvam_mcp/server.py` registers `workflows.meet.register(mcp)`, appended after `recall` to match the existing registration order.

`tests/tools/test_registration.py` adds `sarvam_tools_meet` to `EXPECTED_TOOLS`.

`tests/tools/test_stt.py` is new: unit tests for `_fetch_download_urls()`'s retry logic — succeeds after one retry on the exact consistency-lag error observed live, exhausts all attempts and raises a clear error, and does not retry an unrelated `SarvamBadRequestError`.

`tests/workflows/test_meet.py` is new: unit tests for `_render_diarized_transcript()` and `_parse_meeting_summary()`, covering the fallback-to-plain-transcript case, multi-speaker timestamped rendering, valid JSON, code-fence-wrapped JSON, malformed JSON, and valid-but-non-dict JSON.

## Testing

`pytest -q`: 71 passed (68 from the first commit, 3 new for the retry).

`ruff check`: clean on all changed and new files.

Verified live against the real Sarvam API multiple times, not just unit tests. A full `sv_meet` run against a 21-second recording completed genuinely end to end after the fix: real transcript, real diarized turns, real language code, real summary. Separately, one of those live runs came back with the LLM reply truncated mid-JSON, which `_parse_meeting_summary` handled exactly as designed (`parse_warning` set, no fabricated action items or decisions) rather than crashing, but it's a real, independent flakiness in the LLM completion step, not something this PR fixes or claims to.