### PR TITLE
fix(llm/code): default chat and builder tools to sarvam-105b

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ All defaults below reflect the latest non-deprecated models.
 | `sarvam_transliterate` | Script conversion | — |
 | `sarvam_identify_language` | Language + script detect | — |
 | `sarvam_text_analytics` | Typed Q&A over text | — |
-| `sarvam_llm_complete` | Chat completions | `sarvam-30b` |
+| `sarvam_llm_complete` | Chat completions | `sarvam-105b` |
 | `sarvam_vision_extract` | Document Intelligence | Sarvam Vision |
 | `sarvam_vision_job_status` | Poll Document Intelligence job | — |
 | `sarvam_pronunciation_list` | List pronunciation dictionaries | — |

--- a/src/sarvam_mcp/code/_data.py
+++ b/src/sarvam_mcp/code/_data.py
@@ -47,26 +47,44 @@ ALL_LANGUAGES: list[dict[str, str]] = [
 ]
 
 _TTS_CODES = {
-    "en-IN", "hi-IN", "bn-IN", "ta-IN", "te-IN", "gu-IN",
-    "kn-IN", "ml-IN", "mr-IN", "pa-IN", "od-IN",
+    "en-IN",
+    "hi-IN",
+    "bn-IN",
+    "ta-IN",
+    "te-IN",
+    "gu-IN",
+    "kn-IN",
+    "ml-IN",
+    "mr-IN",
+    "pa-IN",
+    "od-IN",
 }
 
 # LID only supports 11 languages per the /text-lid OpenAPI spec.
 _LID_CODES = {
-    "en-IN", "hi-IN", "bn-IN", "ta-IN", "te-IN", "gu-IN",
-    "kn-IN", "ml-IN", "mr-IN", "pa-IN", "od-IN",
+    "en-IN",
+    "hi-IN",
+    "bn-IN",
+    "ta-IN",
+    "te-IN",
+    "gu-IN",
+    "kn-IN",
+    "ml-IN",
+    "mr-IN",
+    "pa-IN",
+    "od-IN",
 }
 
 # Per-API language coverage. Keys match what the agent might pass.
 LANGUAGES_BY_API: dict[str, list[dict[str, str]]] = {
-    "stt":           ALL_LANGUAGES,
-    "stt_translate": ALL_LANGUAGES,    # Saaras takes any input; output is always English.
-    "tts":           [lang for lang in ALL_LANGUAGES if lang["code"] in _TTS_CODES],
-    "translate":     ALL_LANGUAGES,    # sarvam-translate:v1 covers all; mayura:v1 only TTS subset.
+    "stt": ALL_LANGUAGES,
+    "stt_translate": ALL_LANGUAGES,  # Saaras takes any input; output is always English.
+    "tts": [lang for lang in ALL_LANGUAGES if lang["code"] in _TTS_CODES],
+    "translate": ALL_LANGUAGES,  # sarvam-translate:v1 covers all; mayura:v1 only TTS subset.
     "transliterate": ALL_LANGUAGES,
-    "lid":           [lang for lang in ALL_LANGUAGES if lang["code"] in _LID_CODES],
-    "llm":           ALL_LANGUAGES,
-    "vision":        ALL_LANGUAGES,
+    "lid": [lang for lang in ALL_LANGUAGES if lang["code"] in _LID_CODES],
+    "llm": ALL_LANGUAGES,
+    "vision": ALL_LANGUAGES,
 }
 
 
@@ -75,11 +93,44 @@ LANGUAGES_BY_API: dict[str, list[dict[str, str]]] = {
 # ---------------------------------------------------------------------------
 
 V3_SPEAKERS = [
-    "aditya", "ritu", "ashutosh", "priya", "neha", "rahul", "pooja", "rohan",
-    "simran", "kavya", "amit", "dev", "ishita", "shreya", "ratan", "varun",
-    "manan", "sumit", "roopa", "kabir", "aayan", "shubh", "advait", "anand",
-    "tanya", "tarun", "sunny", "mani", "gokul", "vijay", "shruti", "suhani",
-    "mohit", "kavitha", "rehan", "soham", "rupali", "niharika",
+    "aditya",
+    "ritu",
+    "ashutosh",
+    "priya",
+    "neha",
+    "rahul",
+    "pooja",
+    "rohan",
+    "simran",
+    "kavya",
+    "amit",
+    "dev",
+    "ishita",
+    "shreya",
+    "ratan",
+    "varun",
+    "manan",
+    "sumit",
+    "roopa",
+    "kabir",
+    "aayan",
+    "shubh",
+    "advait",
+    "anand",
+    "tanya",
+    "tarun",
+    "sunny",
+    "mani",
+    "gokul",
+    "vijay",
+    "shruti",
+    "suhani",
+    "mohit",
+    "kavitha",
+    "rehan",
+    "soham",
+    "rupali",
+    "niharika",
 ]
 
 SPEAKERS_BY_MODEL: dict[str, list[str]] = {
@@ -88,20 +139,20 @@ SPEAKERS_BY_MODEL: dict[str, list[str]] = {
 
 # Curated tone hints for the most-used voices, so agents can pick sensibly.
 SPEAKER_HINTS: dict[str, str] = {
-    "priya":    "warm friendly female (default), good for product / IVR",
-    "neha":     "warm female, conversational",
-    "pooja":    "warm female, friendly",
-    "shreya":   "calm female, news-anchor / narration",
-    "kavya":    "calm female, professional",
-    "ritu":     "calm female, professional",
-    "aditya":   "professional male, news-anchor",
-    "rahul":    "professional male, conversational",
-    "kabir":    "professional male, warm",
-    "vijay":    "mature male, authoritative",
-    "gokul":    "mature male, narration",
-    "anand":    "mature male, professional",
-    "tanya":    "young energetic female",
-    "suhani":   "young energetic female",
+    "priya": "warm friendly female (default), good for product / IVR",
+    "neha": "warm female, conversational",
+    "pooja": "warm female, friendly",
+    "shreya": "calm female, news-anchor / narration",
+    "kavya": "calm female, professional",
+    "ritu": "calm female, professional",
+    "aditya": "professional male, news-anchor",
+    "rahul": "professional male, conversational",
+    "kabir": "professional male, warm",
+    "vijay": "mature male, authoritative",
+    "gokul": "mature male, narration",
+    "anand": "mature male, professional",
+    "tanya": "young energetic female",
+    "suhani": "young energetic female",
     "niharika": "young energetic female",
 }
 
@@ -118,18 +169,18 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
         "content_type": "application/json",
         "auth_header": "api-subscription-key",
         "request_body": {
-            "inputs":               "list[str], required — texts to synthesize",
+            "inputs": "list[str], required — texts to synthesize",
             "target_language_code": "str, required — one of TTS-supported codes",
-            "speaker":              "str, required — must be compatible with chosen model",
-            "model":                "str — bulbul:v3 default",
-            "speech_sample_rate":   "int — 8000|16000|22050|24000|32000|44100|48000",
-            "pitch":                "float, -1.0 to 1.0 (default 0)",
-            "pace":                 "float, 0.3 to 3.0 (default 1)",
-            "loudness":             "float, 0.1 to 3.0 (default 1)",
+            "speaker": "str, required — must be compatible with chosen model",
+            "model": "str — bulbul:v3 default",
+            "speech_sample_rate": "int — 8000|16000|22050|24000|32000|44100|48000",
+            "pitch": "float, -1.0 to 1.0 (default 0)",
+            "pace": "float, 0.3 to 3.0 (default 1)",
+            "loudness": "float, 0.1 to 3.0 (default 1)",
             "enable_preprocessing": "bool — normalize numbers/dates/code-mix",
         },
         "response": {
-            "audios":     "list[str] — base64-encoded WAV per input",
+            "audios": "list[str] — base64-encoded WAV per input",
             "request_id": "str",
         },
         "notes": "Pick a speaker compatible with your model — see sarvam_code_speakers.",
@@ -140,19 +191,19 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
         "content_type": "multipart/form-data",
         "auth_header": "api-subscription-key",
         "request_body": {
-            "file":              "binary, required — audio (wav, mp3, ogg, flac, m4a, webm, aac, opus, amr, wma)",
-            "model":             "str — saaras:v3",
-            "mode":              "str — transcribe (default) | translate | verbatim | translit | codemix (saaras:v3 only)",
-            "language_code":     "str — BCP-47 or 'unknown' for auto-detect",
-            "with_timestamps":   "bool",
+            "file": "binary, required — audio (wav, mp3, ogg, flac, m4a, webm, aac, opus, amr, wma)",
+            "model": "str — saaras:v3",
+            "mode": "str — transcribe (default) | translate | verbatim | translit | codemix (saaras:v3 only)",
+            "language_code": "str — BCP-47 or 'unknown' for auto-detect",
+            "with_timestamps": "bool",
             "input_audio_codec": "str (optional) — pcm_s16le | pcm_l16 | pcm_raw (required for PCM files, 16kHz only)",
         },
         "response": {
-            "transcript":           "str",
-            "language_code":        "str — detected if input was 'unknown'",
+            "transcript": "str",
+            "language_code": "str — detected if input was 'unknown'",
             "language_probability": "float — confidence of detected language",
-            "diarized_transcript":  "list[turn] | null",
-            "timestamps":           "list[word_ts] | null",
+            "diarized_transcript": "list[turn] | null",
+            "timestamps": "list[word_ts] | null",
         },
         "notes": (
             "Saaras v3 is the recommended model. It supports 5 output modes via the `mode` parameter. "
@@ -165,13 +216,13 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
         "content_type": "multipart/form-data",
         "auth_header": "api-subscription-key",
         "request_body": {
-            "file":             "binary, required",
-            "model":            "str — saaras:v2.5",
+            "file": "binary, required",
+            "model": "str — saaras:v2.5",
             "with_diarization": "bool",
         },
         "response": {
-            "transcript":           "str — always English",
-            "language_code":        "str — detected source language",
+            "transcript": "str — always English",
+            "language_code": "str — detected source language",
         },
         "notes": "DEPRECATED. Migrate to /speech-to-text with model=saaras:v3 and mode=translate.",
     },
@@ -180,15 +231,15 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
         "model": "saaras:v3 (recommended)",
         "content_type": "application/json",
         "request_body": {
-            "model":           "str",
+            "model": "str",
             "with_timestamps": "bool",
-            "language_code":   "str (optional)",
+            "language_code": "str (optional)",
         },
         "response": {
-            "job_id":                  "str",
-            "input_storage_path":      "str — Azure Blob SAS URL (PUT audio here)",
-            "output_storage_path":     "str — Azure Blob SAS URL (poll for results)",
-            "storage_container_type":  "str — 'Azure'",
+            "job_id": "str",
+            "input_storage_path": "str — Azure Blob SAS URL (PUT audio here)",
+            "output_storage_path": "str — Azure Blob SAS URL (poll for results)",
+            "storage_container_type": "str — 'Azure'",
         },
         "notes": "Async batch flow: init -> upload to SAS -> poll /speech-to-text/job/status?job_id=...",
     },
@@ -197,35 +248,35 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
         "model": "mayura:v1 (11 langs, modes), sarvam-translate:v1 (22 langs)",
         "content_type": "application/json",
         "request_body": {
-            "input":                "str, required",
+            "input": "str, required",
             "source_language_code": "str — BCP-47 or 'auto' for auto-detect",
             "target_language_code": "str — BCP-47",
-            "model":                "str",
-            "mode":                 "str — formal | modern-colloquial | classic-colloquial | code-mixed (Mayura only)",
-            "output_script":        "str — roman | fully-native | spoken-form-in-native (Mayura only)",
-            "numerals_format":      "str — international | native",
-            "speaker_gender":       "str — Male | Female (gendered languages)",
+            "model": "str",
+            "mode": "str — formal | modern-colloquial | classic-colloquial | code-mixed (Mayura only)",
+            "output_script": "str — roman | fully-native | spoken-form-in-native (Mayura only)",
+            "numerals_format": "str — international | native",
+            "speaker_gender": "str — Male | Female (gendered languages)",
             "enable_preprocessing": "bool",
         },
         "response": {
-            "translated_text":      "str",
+            "translated_text": "str",
             "source_language_code": "str",
-            "request_id":           "str",
+            "request_id": "str",
         },
     },
     "/transliterate": {
         "method": "POST",
         "content_type": "application/json",
         "request_body": {
-            "input":                         "str",
-            "source_language_code":          "str",
-            "target_language_code":          "str",
-            "numerals_format":               "str",
-            "spoken_form":                   "bool",
+            "input": "str",
+            "source_language_code": "str",
+            "target_language_code": "str",
+            "numerals_format": "str",
+            "spoken_form": "bool",
             "spoken_form_numerals_language": "str (optional)",
         },
         "response": {
-            "transliterated_text":  "str",
+            "transliterated_text": "str",
             "source_language_code": "str",
         },
     },
@@ -243,7 +294,7 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
         "method": "POST",
         "content_type": "multipart/form-data",
         "request_body": {
-            "text":      "str (form field)",
+            "text": "str (form field)",
             "questions": 'JSON-stringified list of {id, text, type} where type is "boolean" | "enum" | "short answer" | "long answer" | "number". For "enum", also include "options".',
         },
         "response": {"answers": "list[answer]"},
@@ -251,18 +302,21 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
     },
     "/v1/chat/completions": {
         "method": "POST",
-        "model": "sarvam-30b (recommended), sarvam-105b (flagship)",
+        "model": "sarvam-105b (recommended), sarvam-30b (deprecated)",
         "content_type": "application/json",
         "request_body": {
-            "model":       "str — one of: sarvam-30b | sarvam-105b",
-            "messages":    "list[{role, content}]",
+            "model": "str — one of: sarvam-105b | sarvam-30b",
+            "messages": "list[{role, content}]",
             "temperature": "float, 0.0 to 2.0",
-            "top_p":       "float, 0.0 to 1.0",
-            "max_tokens":  "int (optional)",
-            "stream":      "bool",
+            "top_p": "float, 0.0 to 1.0",
+            "max_tokens": "int (recommended; default 1024 in MCP tools)",
+            "stream": "bool",
         },
         "response_oai_compatible": True,
-        "notes": "OpenAI-compatible. sarvam-30b is the recommended default; sarvam-105b is flagship.",
+        "notes": (
+            "OpenAI-compatible. Prefer sarvam-105b for new chat/coding/agent work; "
+            "sarvam-30b is deprecated for new integrations."
+        ),
     },
     "/doc-digitization/job/v1": {
         "method": "POST",
@@ -270,13 +324,13 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
         "content_type": "application/json",
         "request_body": {
             "job_parameters": "object — {language: BCP-47 code, output_format: 'md'|'html'|'json'}",
-            "callback":       "object (optional) — {url: str, auth_token: str} for webhook",
+            "callback": "object (optional) — {url: str, auth_token: str} for webhook",
         },
         "response": {
-            "job_id":                  "str (UUID)",
-            "storage_container_type":  "str",
-            "job_parameters":          "object",
-            "job_state":               "str — Accepted",
+            "job_id": "str (UUID)",
+            "storage_container_type": "str",
+            "job_parameters": "object",
+            "job_state": "str — Accepted",
         },
         "notes": (
             "Job-based async pipeline: create job → get upload URLs "
@@ -294,7 +348,7 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
         },
         "response": {
             "dictionary_count": "int",
-            "dictionaries":     "list[str] — dictionary IDs",
+            "dictionaries": "list[str] — dictionary IDs",
         },
         "notes": "CRUD for pronunciation dictionaries. Also supports GET /{id}, PUT /{id}, DELETE /{id}.",
     },
@@ -308,15 +362,15 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
 # ---------------------------------------------------------------------------
 
 PRICING: dict[str, dict[str, Any]] = {
-    "saaras:v3":            {"unit": "per minute of audio",   "tier": "billed by minute (recommended)"},
-    "saaras:v3-realtime":   {"unit": "per minute of audio",   "tier": "billed by minute"},
-    "saaras:v2.5":          {"unit": "per minute of audio",   "tier": "billed by minute (legacy, deprecated soon)"},
-    "bulbul:v3":            {"unit": "per character",         "tier": "billed by character"},
-    "mayura:v1":            {"unit": "per character",         "tier": "billed by character"},
-    "sarvam-translate:v1":  {"unit": "per character",         "tier": "billed by character"},
-    "sarvam-30b":           {"unit": "per 1M tokens",         "tier": "billed by tokens (recommended)"},
-    "sarvam-105b":          {"unit": "per 1M tokens",         "tier": "billed by tokens (flagship)"},
-    "sarvam-vision":        {"unit": "per page",              "tier": "billed by page"},
+    "saaras:v3": {"unit": "per minute of audio", "tier": "billed by minute (recommended)"},
+    "saaras:v3-realtime": {"unit": "per minute of audio", "tier": "billed by minute"},
+    "saaras:v2.5": {"unit": "per minute of audio", "tier": "billed by minute (legacy, deprecated soon)"},
+    "bulbul:v3": {"unit": "per character", "tier": "billed by character"},
+    "mayura:v1": {"unit": "per character", "tier": "billed by character"},
+    "sarvam-translate:v1": {"unit": "per character", "tier": "billed by character"},
+    "sarvam-105b": {"unit": "per 1M tokens", "tier": "billed by tokens (recommended)"},
+    "sarvam-30b": {"unit": "per 1M tokens", "tier": "billed by tokens (deprecated)"},
+    "sarvam-vision": {"unit": "per page", "tier": "billed by page"},
 }
 
 PRICING_DISCLAIMER = (

--- a/src/sarvam_mcp/code/_snippets.py
+++ b/src/sarvam_mcp/code/_snippets.py
@@ -193,13 +193,13 @@ curl -sS https://api.sarvam.ai/translate \\
 PY_LLM = '''\
 """Chat with Sarvam LLMs (OpenAI-compatible).
 
-Accepted model ids: sarvam-30b (balanced default), sarvam-105b (flagship).
+Accepted model ids: sarvam-105b (recommended), sarvam-30b (deprecated).
 """
 import os, httpx
 
 API_KEY = os.environ["SARVAM_API_KEY"]
-# sarvam-30b | sarvam-105b
-MODEL = "sarvam-30b"
+# Prefer sarvam-105b for new chat/coding/agent work.
+MODEL = "sarvam-105b"
 
 resp = httpx.post(
     "https://api.sarvam.ai/v1/chat/completions",
@@ -211,7 +211,7 @@ resp = httpx.post(
             {"role": "user",   "content": "Translate 'good morning' into Tamil and Marathi."},
         ],
         "temperature": 0.3,
-        "max_tokens": 200,
+        "max_tokens": 1024,
     },
     timeout=60.0,
 )
@@ -220,9 +220,9 @@ print(resp.json()["choices"][0]["message"]["content"])
 '''
 
 JS_LLM = '''\
-// Accepted model ids: sarvam-30b (balanced default), sarvam-105b (flagship).
+// Accepted model ids: sarvam-105b (recommended), sarvam-30b (deprecated).
 const API_KEY = process.env.SARVAM_API_KEY;
-const MODEL = "sarvam-30b";
+const MODEL = "sarvam-105b";
 const resp = await fetch("https://api.sarvam.ai/v1/chat/completions", {
   method: "POST",
   headers: {
@@ -236,7 +236,7 @@ const resp = await fetch("https://api.sarvam.ai/v1/chat/completions", {
       { role: "user",   content: "Translate 'good morning' into Tamil and Marathi." },
     ],
     temperature: 0.3,
-    max_tokens: 200,
+    max_tokens: 1024,
   }),
 });
 const data = await resp.json();
@@ -244,17 +244,16 @@ console.log(data.choices[0].message.content);
 '''
 
 CURL_LLM = '''\
-# Accepted model ids: sarvam-30b (balanced default), sarvam-105b (flagship).
-# Example below uses sarvam-30b; change the "model" field to sarvam-105b if needed.
+# Accepted model ids: sarvam-105b (recommended), sarvam-30b (deprecated).
 curl -sS https://api.sarvam.ai/v1/chat/completions \\
   -H "api-subscription-key: $SARVAM_API_KEY" \\
   -H "content-type: application/json" \\
   -d '{
-    "model": "sarvam-30b",
+    "model": "sarvam-105b",
     "messages": [
       {"role": "user", "content": "Translate good morning to Tamil"}
     ],
-    "max_tokens": 100
+    "max_tokens": 1024
   }' | jq -r '.choices[0].message.content'
 '''
 
@@ -262,20 +261,20 @@ curl -sS https://api.sarvam.ai/v1/chat/completions \\
 
 
 SNIPPETS: dict[tuple[str, str], str] = {
-    ("tts", "python"):           PY_TTS,
-    ("tts", "javascript"):       JS_TTS,
-    ("tts", "typescript"):       JS_TTS,   # same modern Node code works
-    ("tts", "curl"):             CURL_TTS,
-    ("stt", "python"):           PY_STT,
-    ("stt", "javascript"):       JS_STT,
-    ("stt", "typescript"):       JS_STT,
-    ("stt", "curl"):             CURL_STT,
-    ("translate", "python"):     PY_TRANSLATE,
+    ("tts", "python"): PY_TTS,
+    ("tts", "javascript"): JS_TTS,
+    ("tts", "typescript"): JS_TTS,  # same modern Node code works
+    ("tts", "curl"): CURL_TTS,
+    ("stt", "python"): PY_STT,
+    ("stt", "javascript"): JS_STT,
+    ("stt", "typescript"): JS_STT,
+    ("stt", "curl"): CURL_STT,
+    ("translate", "python"): PY_TRANSLATE,
     ("translate", "javascript"): JS_TRANSLATE,
     ("translate", "typescript"): JS_TRANSLATE,
-    ("translate", "curl"):       CURL_TRANSLATE,
-    ("llm", "python"):           PY_LLM,
-    ("llm", "javascript"):       JS_LLM,
-    ("llm", "typescript"):       JS_LLM,
-    ("llm", "curl"):             CURL_LLM,
+    ("translate", "curl"): CURL_TRANSLATE,
+    ("llm", "python"): PY_LLM,
+    ("llm", "javascript"): JS_LLM,
+    ("llm", "typescript"): JS_LLM,
+    ("llm", "curl"): CURL_LLM,
 }

--- a/src/sarvam_mcp/code/snippets.py
+++ b/src/sarvam_mcp/code/snippets.py
@@ -115,20 +115,20 @@ def register(mcp: FastMCP) -> None:
 # ---- recommendation heuristics --------------------------------------------
 
 _LANG_PATTERNS = {
-    "hi-IN":  r"\b(hindi|हिन्दी|hin)\b",
-    "ta-IN":  r"\b(tamil|தமிழ்|tam)\b",
-    "te-IN":  r"\b(telugu|తెలుగు|tel)\b",
-    "bn-IN":  r"\b(bengali|bangla|বাংলা|ben)\b",
-    "mr-IN":  r"\b(marathi|मराठी|mar)\b",
-    "gu-IN":  r"\b(gujarati|ગુજરાતી|guj)\b",
-    "kn-IN":  r"\b(kannada|ಕನ್ನಡ|kan)\b",
-    "ml-IN":  r"\b(malayalam|മലയാളം|mal)\b",
-    "pa-IN":  r"\b(punjabi|ਪੰਜਾਬੀ|pan)\b",
-    "od-IN":  r"\b(oriya|odia|ଓଡ଼ିଆ|ori)\b",
-    "ur-IN":  r"\b(urdu|اردو)\b",
-    "as-IN":  r"\b(assamese|asm)\b",
-    "ne-IN":  r"\b(nepali|nepalese|nep)\b",
-    "en-IN":  r"\b(english|eng)\b",
+    "hi-IN": r"\b(hindi|हिन्दी|hin)\b",
+    "ta-IN": r"\b(tamil|தமிழ்|tam)\b",
+    "te-IN": r"\b(telugu|తెలుగు|tel)\b",
+    "bn-IN": r"\b(bengali|bangla|বাংলা|ben)\b",
+    "mr-IN": r"\b(marathi|मराठी|mar)\b",
+    "gu-IN": r"\b(gujarati|ગુજરાતી|guj)\b",
+    "kn-IN": r"\b(kannada|ಕನ್ನಡ|kan)\b",
+    "ml-IN": r"\b(malayalam|മലയാളം|mal)\b",
+    "pa-IN": r"\b(punjabi|ਪੰਜਾਬੀ|pan)\b",
+    "od-IN": r"\b(oriya|odia|ଓଡ଼ିଆ|ori)\b",
+    "ur-IN": r"\b(urdu|اردو)\b",
+    "as-IN": r"\b(assamese|asm)\b",
+    "ne-IN": r"\b(nepali|nepalese|nep)\b",
+    "en-IN": r"\b(english|eng)\b",
 }
 
 
@@ -146,7 +146,9 @@ def _recommend(task: str) -> dict[str, Any]:
     detected_lang = _detect_language_code(t)
 
     # ---- speech in
-    if re.search(r"\b(transcrib\w*|stt|speech.{0,5}to.{0,5}text|voice ?memo|voicemail\w*|recording|audio file)\b", t):
+    if re.search(
+        r"\b(transcrib\w*|stt|speech.{0,5}to.{0,5}text|voice ?memo|voicemail\w*|recording|audio file)\b", t
+    ):
         if "english" in t or re.search(r"into english|to english", t):
             return _result(
                 model="saaras:v3",
@@ -178,14 +180,16 @@ def _recommend(task: str) -> dict[str, Any]:
             snippet_key=("tts", "python"),
             extras={
                 "default_speaker": "priya",
-                "tip_speakers":    "Call sarvam_code_speakers('bulbul:v3') for the full voice list with tone hints.",
+                "tip_speakers": "Call sarvam_code_speakers('bulbul:v3') for the full voice list with tone hints.",
             },
         )
 
     # ---- text translation
     if re.search(r"\btransla(te|ting)\b", t):
         # If 22-language coverage signal, pick sarvam-translate.
-        if re.search(r"\b(22|all indi(c|an) languages|all indian|kashmiri|sindhi|santali|bodo|maithili|dogri)\b", t):
+        if re.search(
+            r"\b(22|all indi(c|an) languages|all indian|kashmiri|sindhi|santali|bodo|maithili|dogri)\b", t
+        ):
             return _result(
                 model="sarvam-translate:v1",
                 endpoint="/translate",
@@ -213,20 +217,32 @@ def _recommend(task: str) -> dict[str, Any]:
         )
 
     # ---- chat / LLM / agent
-    if re.search(r"\b(chat|chatbot|llm|agent|generate text|reply|conversation|reasoning|reasoning agent)\b", t):
-        # Bigger model when 'reasoning'/'tool use'/'flagship' signals appear.
-        if re.search(r"\b(reasoning|complex|flagship|best|highest quality|tool use)\b", t):
+    if re.search(
+        r"\b(chat|chatbot|llm|agent|coding|coding agent|code assistant|write code|generate text|reply|conversation|reasoning)\b",
+        t,
+    ):
+        # Latency-sensitive realtime paths can still call out 30b explicitly; new
+        # chat/coding/agent work defaults to the flagship 105b.
+        if re.search(r"\b(realtime|low[- ]latency|ivr)\b", t) and not re.search(
+            r"\b(reasoning|complex|flagship|coding|code assistant|write code|tool use)\b", t
+        ):
             return _result(
-                model="sarvam-105b",
+                model="sarvam-30b",
                 endpoint="/v1/chat/completions",
-                why="Highest-quality reasoning + tool use across Indic languages.",
+                why=(
+                    "Sarvam-30B — lower latency for voice/realtime paths. "
+                    "Prefer sarvam-105b for coding, reasoning, and new integrations."
+                ),
                 language_code=detected_lang,
                 snippet_key=("llm", "python"),
             )
         return _result(
-            model="sarvam-30b",
+            model="sarvam-105b",
             endpoint="/v1/chat/completions",
-            why="Sarvam-30B — balanced quality + cost, recommended default for chat/agents in Indic languages.",
+            why=(
+                "Sarvam-105B — recommended default for chat, coding agents, reasoning, "
+                "and tool use across Indic languages (sarvam-30b is deprecated for new work)."
+            ),
             language_code=detected_lang,
             snippet_key=("llm", "python"),
         )
@@ -317,24 +333,35 @@ def _validate(endpoint: str, body: dict[str, Any]) -> list[dict[str, Any]]:
         if not body.get("target_language_code"):
             issues.append(_err("target_language_code", "Required."))
         elif body["target_language_code"] not in _TTS_LANG_CODES:
-            issues.append(_err(
-                "target_language_code",
-                f"'{body['target_language_code']}' not supported by TTS.",
-                "TTS covers 11 codes; call sarvam_code_languages('tts').",
-            ))
+            issues.append(
+                _err(
+                    "target_language_code",
+                    f"'{body['target_language_code']}' not supported by TTS.",
+                    "TTS covers 11 codes; call sarvam_code_languages('tts').",
+                )
+            )
         model = body.get("model", "bulbul:v3")
         if model not in _VALID_TTS_MODELS:
-            issues.append(_err("model", f"'{model}' invalid for TTS.",
-                               f"Use one of: {sorted(_VALID_TTS_MODELS)}"))
+            issues.append(
+                _err("model", f"'{model}' invalid for TTS.", f"Use one of: {sorted(_VALID_TTS_MODELS)}")
+            )
         speaker = body.get("speaker")
         if speaker and model in _data.SPEAKERS_BY_MODEL:
             allowed = _data.SPEAKERS_BY_MODEL[model]
             if speaker not in allowed:
-                fix = (f"Speakers compatible with {model}: "
-                       f"{', '.join(allowed[:8])}, … Call sarvam_code_speakers('{model}').")
+                fix = (
+                    f"Speakers compatible with {model}: "
+                    f"{', '.join(allowed[:8])}, … Call sarvam_code_speakers('{model}')."
+                )
                 issues.append(_err("speaker", f"'{speaker}' not compatible with {model}.", fix))
         if "speech_sample_rate" in body and body["speech_sample_rate"] not in (
-            8000, 16000, 22050, 24000, 32000, 44100, 48000
+            8000,
+            16000,
+            22050,
+            24000,
+            32000,
+            44100,
+            48000,
         ):
             issues.append(_err("speech_sample_rate", "Invalid sample rate."))
 
@@ -343,12 +370,10 @@ def _validate(endpoint: str, body: dict[str, Any]) -> list[dict[str, Any]]:
             issues.append(_warn("file", "Required (multipart). Pass the audio file separately."))
         model = body.get("model", "saaras:v3")
         if model not in _VALID_STT_MODELS:
-            issues.append(_err("model", f"'{model}' invalid for STT.",
-                               "Use 'saaras:v3'."))
+            issues.append(_err("model", f"'{model}' invalid for STT.", "Use 'saaras:v3'."))
         mode = body.get("mode")
         if mode and mode not in _VALID_STT_MODES:
-            issues.append(_err("mode", f"'{mode}' invalid.",
-                               f"Valid modes: {sorted(_VALID_STT_MODES)}"))
+            issues.append(_err("mode", f"'{mode}' invalid.", f"Valid modes: {sorted(_VALID_STT_MODES)}"))
         lc = body.get("language_code", "unknown")
         if lc not in _VALID_LANGUAGE_CODES:
             issues.append(_err("language_code", f"Unknown code '{lc}'."))
@@ -356,8 +381,7 @@ def _validate(endpoint: str, body: dict[str, Any]) -> list[dict[str, Any]]:
     elif endpoint == "/speech-to-text-translate":
         model = body.get("model", "saaras:v3")
         if model not in _VALID_SAARAS_MODELS:
-            issues.append(_err("model", f"'{model}' invalid.",
-                               f"Use one of: {sorted(_VALID_SAARAS_MODELS)}"))
+            issues.append(_err("model", f"'{model}' invalid.", f"Use one of: {sorted(_VALID_SAARAS_MODELS)}"))
 
     elif endpoint == "/translate":
         for f in ("input", "source_language_code", "target_language_code"):
@@ -369,19 +393,28 @@ def _validate(endpoint: str, body: dict[str, Any]) -> list[dict[str, Any]]:
                 issues.append(_err(f, f"Unknown language code '{v}'."))
         model = body.get("model", "mayura:v1")
         if model not in _VALID_TRANSLATE_MODELS:
-            issues.append(_err("model", f"'{model}' invalid for translate.",
-                               f"Use one of: {sorted(_VALID_TRANSLATE_MODELS)}"))
+            issues.append(
+                _err(
+                    "model",
+                    f"'{model}' invalid for translate.",
+                    f"Use one of: {sorted(_VALID_TRANSLATE_MODELS)}",
+                )
+            )
         if model == "sarvam-translate:v1" and body.get("mode"):
-            issues.append(_warn("mode", "Sarvam-Translate v1 ignores `mode` — formal only.",
-                                "Drop the field or switch to mayura:v1 if you need modes."))
+            issues.append(
+                _warn(
+                    "mode",
+                    "Sarvam-Translate v1 ignores `mode` — formal only.",
+                    "Drop the field or switch to mayura:v1 if you need modes.",
+                )
+            )
 
     elif endpoint == "/v1/chat/completions":
         if not body.get("messages"):
             issues.append(_err("messages", "Required."))
-        model = body.get("model", "sarvam-30b")
+        model = body.get("model", "sarvam-105b")
         if model not in _VALID_LLM_MODELS:
-            issues.append(_err("model", f"'{model}' invalid.",
-                               f"Valid: {sorted(_VALID_LLM_MODELS)}"))
+            issues.append(_err("model", f"'{model}' invalid.", f"Valid: {sorted(_VALID_LLM_MODELS)}"))
         t = body.get("temperature")
         if t is not None and not (0.0 <= t <= 2.0):
             issues.append(_err("temperature", "Must be between 0.0 and 2.0."))
@@ -401,15 +434,21 @@ def _validate(endpoint: str, body: dict[str, Any]) -> list[dict[str, Any]]:
                 missing = {"id", "text", "type"} - set(q.keys())
                 if missing:
                     for mf in sorted(missing):
-                        issues.append(_err(
-                            f"questions[{i}].{mf}",
-                            f"Missing required field '{mf}'.",
-                            "Each question needs id, text, type.",
-                        ))
+                        issues.append(
+                            _err(
+                                f"questions[{i}].{mf}",
+                                f"Missing required field '{mf}'.",
+                                "Each question needs id, text, type.",
+                            )
+                        )
                 if q.get("type") and q["type"] not in valid_types:
-                    issues.append(_err(f"questions[{i}].type",
-                                       f"Invalid type '{q['type']}'.",
-                                       f"Allowed: {sorted(valid_types)}"))
+                    issues.append(
+                        _err(
+                            f"questions[{i}].type",
+                            f"Invalid type '{q['type']}'.",
+                            f"Allowed: {sorted(valid_types)}",
+                        )
+                    )
 
     elif endpoint == "/text-lid":
         if not body.get("input"):

--- a/src/sarvam_mcp/tools/llm.py
+++ b/src/sarvam_mcp/tools/llm.py
@@ -22,27 +22,35 @@ def register(mcp: FastMCP) -> None:
             "Runtime tool — calls Sarvam API now. For code-writing help, use sarvam_code_* tools.\n\n"
             "Generate chat completions with Sarvam's Indic-tuned LLMs.\n\n"
             "Models:\n"
-            "  • `sarvam-30b` (default) — MoE, 2.4B active, balanced quality + cost\n"
-            "  • `sarvam-105b` — MoE flagship, best reasoning + tool use\n\n"
+            "  • `sarvam-105b` (default) — MoE flagship, best reasoning + tool use + coding\n"
+            "  • `sarvam-30b` (deprecated) — kept for compatibility; prefer 105b for new work\n\n"
             "Both support 23 Indic languages with native, romanized, and "
-            "code-mixed styles. OpenAI-compatible message format."
+            "code-mixed styles. OpenAI-compatible message format. "
+            "A default max_tokens budget is always sent so reasoning does not "
+            "consume the whole response and leave content empty."
         ),
     )
     async def sarvam_llm_complete(
         ctx: Context,
         messages: list[dict[str, Any]] = Field(
             description=(
-                "OpenAI-style messages: [{'role': 'system'|'user'|'assistant', "
-                "'content': '...'}, ...]"
+                "OpenAI-style messages: [{'role': 'system'|'user'|'assistant', 'content': '...'}, ...]"
             ),
         ),
         model: SarvamLLM = Field(
-            default="sarvam-30b",
-            description="`sarvam-30b` (default) or `sarvam-105b` (flagship).",
+            default="sarvam-105b",
+            description="`sarvam-105b` (default/flagship) or `sarvam-30b` (deprecated).",
         ),
         temperature: float = Field(default=0.7, ge=0.0, le=2.0),
         top_p: float = Field(default=1.0, ge=0.0, le=1.0),
-        max_tokens: int | None = Field(default=None, ge=1),
+        max_tokens: int | None = Field(
+            default=1024,
+            ge=1,
+            description=(
+                "Max completion tokens. Defaults to 1024 so reasoning models do not "
+                "return empty content when the budget is exhausted."
+            ),
+        ),
         stream: bool = Field(
             default=False,
             description="Streaming via MCP isn't useful for chat — keep False unless testing.",
@@ -55,9 +63,8 @@ def register(mcp: FastMCP) -> None:
             "temperature": temperature,
             "top_p": top_p,
             "stream": stream,
+            "max_tokens": max_tokens if max_tokens is not None else 1024,
         }
-        if max_tokens is not None:
-            body["max_tokens"] = max_tokens
 
         with measure_tool() as metrics:
             payload, call = await sc.client.post_json(CHAT_PATH, json_body=body)

--- a/tests/code/test_recommend_and_validate.py
+++ b/tests/code/test_recommend_and_validate.py
@@ -42,6 +42,25 @@ def test_recommend_picks_105b_for_reasoning_signal():
     assert result["recommended_model"] == "sarvam-105b"
 
 
+def test_recommend_picks_105b_for_default_chatbot():
+    result = _recommend("build a chatbot that replies in Hindi")
+    assert result["matched"]
+    assert result["recommended_model"] == "sarvam-105b"
+    assert result["endpoint"] == "/v1/chat/completions"
+
+
+def test_recommend_picks_105b_for_coding_agent():
+    result = _recommend("write a coding agent with tool use")
+    assert result["matched"]
+    assert result["recommended_model"] == "sarvam-105b"
+
+
+def test_recommend_picks_30b_for_low_latency_chat():
+    result = _recommend("low-latency realtime chatbot for IVR")
+    assert result["matched"]
+    assert result["recommended_model"] == "sarvam-30b"
+
+
 def test_recommend_returns_unmatched_for_unrelated():
     result = _recommend("sort my photos by date")
     assert result["matched"] is False
@@ -112,7 +131,7 @@ def test_validate_clean_request_returns_no_errors():
     issues = _validate(
         "/v1/chat/completions",
         {
-            "model": "sarvam-30b",
+            "model": "sarvam-105b",
             "messages": [{"role": "user", "content": "hi"}],
             "temperature": 0.5,
         },


### PR DESCRIPTION
## Summary

Coding agents (Cursor / Claude Code / Codex / Sarvam Code harnesses) use this MCP server for both **live** chat (`sarvam_tools_llm_complete`) and **build-time** guidance (`sarvam_code_*`). Those surfaces still defaulted to deprecated **`sarvam-30b`**, which steers agents away from the flagship model and conflicts with the README claim that defaults reflect non-deprecated models.

## Changes

- `sarvam_tools_llm_complete` default model → **`sarvam-105b`**
- Always send **`max_tokens` (default 1024)** so reasoning does not eat the budget and return empty `content`
- `sarvam_code_recommend_model` defaults chat/coding/agent tasks to **105b**; keeps **30b** only for explicit low-latency/realtime/IVR signals
- Update LLM snippets + API reference notes + pricing tier labels
- README tools table default for `sarvam_llm_complete` → `sarvam-105b`

Voice/recall workflow tool defaults stay on `sarvam-30b` for latency (same rationale as the voice-agents skill).

## Test plan

- [x] `pytest -q` → **64 passed**
- [x] `ruff check` / `ruff format` clean on touched files
- [x] Recommend smoke: chatbot/coding → 105b; low-latency realtime IVR → 30b; translate/transcribe code-mixed still hit translate/STT

Pairs with the skills alignment PR: https://github.com/sarvamai/skills/pull/5