### PR TITLE
chore: migrate LLM references from deprecated sarvam-30b to sarvam-105b

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ All defaults below reflect the latest non-deprecated models.
 | `sarvam_transliterate` | Script conversion | — |
 | `sarvam_identify_language` | Language + script detect | — |
 | `sarvam_text_analytics` | Typed Q&A over text | — |
-| `sarvam_llm_complete` | Chat completions | `sarvam-30b` |
+| `sarvam_llm_complete` | Chat completions | `sarvam-105b` |
 | `sarvam_vision_extract` | Document Intelligence | Sarvam Vision |
 | `sarvam_vision_job_status` | Poll Document Intelligence job | — |
 | `sarvam_pronunciation_list` | List pronunciation dictionaries | — |

--- a/scripts/smoke_live.py
+++ b/scripts/smoke_live.py
@@ -253,7 +253,7 @@ async def main() -> None:
         client.post_json(
             "/v1/chat/completions",
             json_body={
-                "model": "sarvam-30b",
+                "model": "sarvam-105b",
                 "messages": [
                     {"role": "system", "content": "You are a concise Indic-language expert."},
                     {"role": "user", "content": "Translate 'good morning' into Tamil and Marathi."},

--- a/src/sarvam_mcp/code/_data.py
+++ b/src/sarvam_mcp/code/_data.py
@@ -251,10 +251,10 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
     },
     "/v1/chat/completions": {
         "method": "POST",
-        "model": "sarvam-30b (recommended), sarvam-105b (flagship)",
+        "model": "sarvam-105b (flagship, sole current model)",
         "content_type": "application/json",
         "request_body": {
-            "model":       "str — one of: sarvam-30b | sarvam-105b",
+            "model":       "str — sarvam-105b",
             "messages":    "list[{role, content}]",
             "temperature": "float, 0.0 to 2.0",
             "top_p":       "float, 0.0 to 1.0",
@@ -262,7 +262,7 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
             "stream":      "bool",
         },
         "response_oai_compatible": True,
-        "notes": "OpenAI-compatible. sarvam-30b is the recommended default; sarvam-105b is flagship.",
+        "notes": "OpenAI-compatible. sarvam-30b was deprecated by Sarvam; sarvam-105b is the sole current model.",
     },
     "/doc-digitization/job/v1": {
         "method": "POST",
@@ -314,7 +314,6 @@ PRICING: dict[str, dict[str, Any]] = {
     "bulbul:v3":            {"unit": "per character",         "tier": "billed by character"},
     "mayura:v1":            {"unit": "per character",         "tier": "billed by character"},
     "sarvam-translate:v1":  {"unit": "per character",         "tier": "billed by character"},
-    "sarvam-30b":           {"unit": "per 1M tokens",         "tier": "billed by tokens (recommended)"},
     "sarvam-105b":          {"unit": "per 1M tokens",         "tier": "billed by tokens (flagship)"},
     "sarvam-vision":        {"unit": "per page",              "tier": "billed by page"},
 }

--- a/src/sarvam_mcp/code/_snippets.py
+++ b/src/sarvam_mcp/code/_snippets.py
@@ -191,15 +191,14 @@ curl -sS https://api.sarvam.ai/translate \\
 '''
 
 PY_LLM = '''\
-"""Chat with Sarvam LLMs (OpenAI-compatible).
+"""Chat with Sarvam LLM (OpenAI-compatible).
 
-Accepted model ids: sarvam-30b (balanced default), sarvam-105b (flagship).
+Accepted model id: sarvam-105b (flagship, the sole current chat model).
 """
 import os, httpx
 
 API_KEY = os.environ["SARVAM_API_KEY"]
-# sarvam-30b | sarvam-105b
-MODEL = "sarvam-30b"
+MODEL = "sarvam-105b"
 
 resp = httpx.post(
     "https://api.sarvam.ai/v1/chat/completions",
@@ -220,9 +219,9 @@ print(resp.json()["choices"][0]["message"]["content"])
 '''
 
 JS_LLM = '''\
-// Accepted model ids: sarvam-30b (balanced default), sarvam-105b (flagship).
+// Accepted model id: sarvam-105b (flagship, the sole current chat model).
 const API_KEY = process.env.SARVAM_API_KEY;
-const MODEL = "sarvam-30b";
+const MODEL = "sarvam-105b";
 const resp = await fetch("https://api.sarvam.ai/v1/chat/completions", {
   method: "POST",
   headers: {
@@ -244,13 +243,12 @@ console.log(data.choices[0].message.content);
 '''
 
 CURL_LLM = '''\
-# Accepted model ids: sarvam-30b (balanced default), sarvam-105b (flagship).
-# Example below uses sarvam-30b; change the "model" field to sarvam-105b if needed.
+# Accepted model id: sarvam-105b (flagship, the sole current chat model).
 curl -sS https://api.sarvam.ai/v1/chat/completions \\
   -H "api-subscription-key: $SARVAM_API_KEY" \\
   -H "content-type: application/json" \\
   -d '{
-    "model": "sarvam-30b",
+    "model": "sarvam-105b",
     "messages": [
       {"role": "user", "content": "Translate good morning to Tamil"}
     ],

--- a/src/sarvam_mcp/code/snippets.py
+++ b/src/sarvam_mcp/code/snippets.py
@@ -214,19 +214,10 @@ def _recommend(task: str) -> dict[str, Any]:
 
     # ---- chat / LLM / agent
     if re.search(r"\b(chat|chatbot|llm|agent|generate text|reply|conversation|reasoning|reasoning agent)\b", t):
-        # Bigger model when 'reasoning'/'tool use'/'flagship' signals appear.
-        if re.search(r"\b(reasoning|complex|flagship|best|highest quality|tool use)\b", t):
-            return _result(
-                model="sarvam-105b",
-                endpoint="/v1/chat/completions",
-                why="Highest-quality reasoning + tool use across Indic languages.",
-                language_code=detected_lang,
-                snippet_key=("llm", "python"),
-            )
         return _result(
-            model="sarvam-30b",
+            model="sarvam-105b",
             endpoint="/v1/chat/completions",
-            why="Sarvam-30B — balanced quality + cost, recommended default for chat/agents in Indic languages.",
+            why="Sarvam-105B — flagship model, best reasoning + tool use across Indic languages. The sole current chat model (sarvam-30b was deprecated).",
             language_code=detected_lang,
             snippet_key=("llm", "python"),
         )
@@ -291,7 +282,7 @@ def _result(
 # ---- request validation ---------------------------------------------------
 
 _VALID_TTS_MODELS = {"bulbul:v3"}
-_VALID_LLM_MODELS = {"sarvam-30b", "sarvam-105b"}
+_VALID_LLM_MODELS = {"sarvam-105b"}
 _VALID_TRANSLATE_MODELS = {"mayura:v1", "sarvam-translate:v1"}
 _VALID_STT_MODELS = {"saaras:v3"}
 _VALID_STT_MODES = {"transcribe", "translate", "verbatim", "translit", "codemix"}
@@ -378,7 +369,7 @@ def _validate(endpoint: str, body: dict[str, Any]) -> list[dict[str, Any]]:
     elif endpoint == "/v1/chat/completions":
         if not body.get("messages"):
             issues.append(_err("messages", "Required."))
-        model = body.get("model", "sarvam-30b")
+        model = body.get("model", "sarvam-105b")
         if model not in _VALID_LLM_MODELS:
             issues.append(_err("model", f"'{model}' invalid.",
                                f"Valid: {sorted(_VALID_LLM_MODELS)}"))

--- a/src/sarvam_mcp/tools/_common.py
+++ b/src/sarvam_mcp/tools/_common.py
@@ -152,7 +152,8 @@ BulbulSpeaker = Literal[
 ]
 
 # Chat completions — same IDs as ``sarvam_tools_llm_complete``.
-SarvamLLM = Literal["sarvam-30b", "sarvam-105b"]
+# sarvam-30b was deprecated by Sarvam; sarvam-105b is the sole current model.
+SarvamLLM = Literal["sarvam-105b"]
 
 
 # ---- Translate-mode + script enums ---------------------------------------

--- a/src/sarvam_mcp/tools/llm.py
+++ b/src/sarvam_mcp/tools/llm.py
@@ -20,11 +20,9 @@ def register(mcp: FastMCP) -> None:
         name="sarvam_tools_llm_complete",
         description=(
             "Runtime tool — calls Sarvam API now. For code-writing help, use sarvam_code_* tools.\n\n"
-            "Generate chat completions with Sarvam's Indic-tuned LLMs.\n\n"
-            "Models:\n"
-            "  • `sarvam-30b` (default) — MoE, 2.4B active, balanced quality + cost\n"
-            "  • `sarvam-105b` — MoE flagship, best reasoning + tool use\n\n"
-            "Both support 23 Indic languages with native, romanized, and "
+            "Generate chat completions with Sarvam's Indic-tuned LLM.\n\n"
+            "Model: `sarvam-105b` — MoE flagship, best reasoning + tool use. "
+            "Supports 23 Indic languages with native, romanized, and "
             "code-mixed styles. OpenAI-compatible message format."
         ),
     )
@@ -37,8 +35,8 @@ def register(mcp: FastMCP) -> None:
             ),
         ),
         model: SarvamLLM = Field(
-            default="sarvam-30b",
-            description="`sarvam-30b` (default) or `sarvam-105b` (flagship).",
+            default="sarvam-105b",
+            description="`sarvam-105b` (flagship, the only current chat model).",
         ),
         temperature: float = Field(default=0.7, ge=0.0, le=2.0),
         top_p: float = Field(default=1.0, ge=0.0, le=1.0),

--- a/src/sarvam_mcp/workflows/_helpers.py
+++ b/src/sarvam_mcp/workflows/_helpers.py
@@ -119,7 +119,7 @@ async def llm_complete(
     sc: ServerContext,
     messages: list[dict[str, Any]],
     *,
-    model: SarvamLLM = "sarvam-30b",
+    model: SarvamLLM = "sarvam-105b",
     temperature: float = 0.4,
     max_tokens: int = 600,
     metrics: ToolMetrics | None = None,

--- a/src/sarvam_mcp/workflows/recall.py
+++ b/src/sarvam_mcp/workflows/recall.py
@@ -54,8 +54,8 @@ def register(mcp: FastMCP) -> None:
         ),
         max_files: int = Field(default=20, ge=1, le=100),
         llm_model: SarvamLLM = Field(
-            default="sarvam-30b",
-            description="`sarvam-30b` (default) or `sarvam-105b` (flagship).",
+            default="sarvam-105b",
+            description="`sarvam-105b` (flagship, the only current chat model).",
         ),
     ) -> dict[str, Any]:
         sc = await ready_ctx(ctx)

--- a/src/sarvam_mcp/workflows/voice.py
+++ b/src/sarvam_mcp/workflows/voice.py
@@ -66,8 +66,8 @@ def register(mcp: FastMCP) -> None:
         ),
         speaker: BulbulSpeaker = Field(default="priya"),
         llm_model: SarvamLLM = Field(
-            default="sarvam-30b",
-            description="`sarvam-30b` (default) or `sarvam-105b` (flagship).",
+            default="sarvam-105b",
+            description="`sarvam-105b` (flagship, the only current chat model).",
         ),
     ) -> dict[str, Any]:
         sc = await ready_ctx(ctx)

--- a/tests/code/test_data.py
+++ b/tests/code/test_data.py
@@ -35,7 +35,7 @@ def test_pricing_table_covers_every_model_in_reference():
             for chunk in model_str.split(","):
                 # Pull bare model ids out of the human-readable list.
                 for word in chunk.split():
-                    if ":" in word or word in {"sarvam-30b", "sarvam-105b"}:
+                    if ":" in word or word in {"sarvam-105b"}:
                         referenced_models.add(word.strip(",.()"))
     # Every referenced model must appear in PRICING.
     missing = referenced_models - _data.PRICING.keys()

--- a/tests/code/test_recommend_and_validate.py
+++ b/tests/code/test_recommend_and_validate.py
@@ -112,7 +112,7 @@ def test_validate_clean_request_returns_no_errors():
     issues = _validate(
         "/v1/chat/completions",
         {
-            "model": "sarvam-30b",
+            "model": "sarvam-105b",
             "messages": [{"role": "user", "content": "hi"}],
             "temperature": 0.5,
         },

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -29,7 +29,7 @@ def test_redact_is_case_insensitive_and_nested():
 def test_redact_preserves_benign_keys():
     # `max_tokens` contains the substring "token" but is not a secret — exact
     # key matching must leave it untouched.
-    payload = {"max_tokens": 600, "model": "sarvam-30b", "temperature": 0.7}
+    payload = {"max_tokens": 600, "model": "sarvam-105b", "temperature": 0.7}
     assert _redact(payload) == payload
 
 


### PR DESCRIPTION
sarvam-30b has been deprecated by Sarvam (confirmed live: the chat completions API now returns 400 "Model 'sarvam-30b' has been deprecated... use sarvam-105b" and docs.sarvam.ai lists it as deprecated). sarvam-105b is now the sole current chat model, so the SarvamLLM type, tool defaults/descriptions, recommendation heuristics, reference data, code snippets, README, and tests are updated accordingly. Other Sarvam model families (saaras:v3, bulbul:v3, mayura:v1, sarvam-translate:v1, sarvam-vision) were checked against docs.sarvam.ai and are already current — no changes needed there.