### PR TITLE
Fix/recall bounded traversal

### DIFF
--- a/src/sarvam_mcp/workflows/recall.py
+++ b/src/sarvam_mcp/workflows/recall.py
@@ -8,6 +8,8 @@ vector store; the v1 contract is intentionally tiny and stateless.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from itertools import islice
 from pathlib import Path
 from typing import Any
 
@@ -144,21 +146,18 @@ def register(mcp: FastMCP) -> None:
 
 
 def _gather_files(paths: list[str], max_files: int) -> list[Path]:
-    out: list[Path] = []
-    for raw in paths:
-        p = Path(raw).expanduser()
-        if p.is_file():
-            if _supported(p):
-                out.append(p)
-        elif p.is_dir():
-            for sub in sorted(p.rglob("*")):
-                if sub.is_file() and _supported(sub):
-                    out.append(sub)
-                if len(out) >= max_files:
-                    break
-        if len(out) >= max_files:
-            break
-    return out[:max_files]
+    def _iter_supported() -> Iterator[Path]:
+        for raw in paths:
+            p = Path(raw).expanduser()
+            if p.is_file():
+                if _supported(p):
+                    yield p
+            elif p.is_dir():
+                for sub in p.rglob("*"):
+                    if sub.is_file() and _supported(sub):
+                        yield sub
+
+    return list(islice(_iter_supported(), max_files))
 
 
 def _supported(p: Path) -> bool:

--- a/tests/test_recall_gather_bound.py
+++ b/tests/test_recall_gather_bound.py
@@ -1,13 +1,4 @@
-"""Behavioral test for the _gather_files lazy-cap fix.
-
-No timing assertions (flaky in CI). We count how many entries `rglob`
-actually yields. With `sorted(p.rglob("*"))`, the full generator is
-drained (~505 entries) before the max_files cap can trigger. With the
-lazy `islice` cap, iteration stops after ~max_files supported files.
-
-Technique: monkeypatch the `Path` symbol imported into the recall module
-with a subclass whose rglob counts yields.
-"""
+"""Tests that _gather_files stops walking once max_files is reached."""
 
 from __future__ import annotations
 
@@ -18,6 +9,8 @@ import pytest
 import sarvam_mcp.workflows.recall as recall
 
 
+# No timing asserts (flaky in CI): monkeypatch recall.Path with a subclass
+# that counts rglob yields, then assert the walk stops near max_files.
 class CountingPath(type(Path())):
     """Path subclass whose rglob counts yielded entries."""
 
@@ -25,8 +18,6 @@ class CountingPath(type(Path())):
 
     def rglob(self, pattern):
         for entry in super().rglob(pattern):
-            CountingPath.yields += 1
-            yield entry
             CountingPath.yields += 1
             yield entry
 

--- a/tests/test_recall_gather_bound.py
+++ b/tests/test_recall_gather_bound.py
@@ -1,0 +1,84 @@
+"""Behavioral test for the _gather_files lazy-cap fix.
+
+No timing assertions (flaky in CI). We count how many entries `rglob`
+actually yields. With `sorted(p.rglob("*"))`, the full generator is
+drained (~505 entries) before the max_files cap can trigger. With the
+lazy `islice` cap, iteration stops after ~max_files supported files.
+
+Technique: monkeypatch the `Path` symbol imported into the recall module
+with a subclass whose rglob counts yields.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import sarvam_mcp.workflows.recall as recall
+
+
+class CountingPath(type(Path())):
+    """Path subclass whose rglob counts yielded entries."""
+
+    yields = 0
+
+    def rglob(self, pattern):
+        for entry in super().rglob(pattern):
+            CountingPath.yields += 1
+            yield entry
+            CountingPath.yields += 1
+            yield entry
+
+
+def test_gather_is_lazy_and_caps_walked_entries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "corpus"
+    root.mkdir()
+    for d in range(5):
+        sub = root / f"dir_{d}"
+        sub.mkdir()
+        for f in range(100):
+            (sub / f"note_{f:03d}.txt").write_text("lorem ipsum")
+    total_entries = sum(1 for _ in root.rglob("*"))  # 505 (500 files + 5 dirs)
+
+    CountingPath.yields = 0
+    monkeypatch.setattr(recall, "Path", CountingPath)
+
+    result = recall._gather_files([str(root)], max_files=20)
+
+    assert len(result) == 20
+    # Lazy cap: ~20 entries visited, NOT ~505. Old sorted() drained all.
+    assert CountingPath.yields < total_entries // 2, (
+        f"rglob yielded {CountingPath.yields} of {total_entries} entries "
+        f"with max_files=20; expected lazy cap to stop near 20"
+    )
+
+
+def test_global_cap_across_dirs(tmp_path: Path) -> None:
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    for d in (dir_a, dir_b):
+        sub = d / "inner"
+        sub.mkdir(parents=True)
+        for f in range(50):
+            (sub / f"file_{f:03d}.txt").write_text("x")
+
+    result = recall._gather_files([str(dir_a), str(dir_b)], max_files=20)
+
+    # Global cap: 20 total across BOTH dirs, not 20 per dir.
+    assert len(result) == 20
+    # Every result lives under one of the two input dirs
+    assert all(any(d in p.parents for d in (dir_a, dir_b)) for p in result)
+
+
+def test_single_file_input_unchanged(tmp_path: Path) -> None:
+    f_ok = tmp_path / "ok.txt"
+    f_ok.write_text("hello")
+    f_bad = tmp_path / "skip.exe"
+    f_bad.write_text("mz")
+
+    got_ok = recall._gather_files([str(f_ok)], max_files=20)
+    got_bad = recall._gather_files([str(f_bad)], max_files=20)
+
+    assert got_ok == [f_ok]
+    assert got_bad == []


### PR DESCRIPTION
Closes #70 

### issue
`_gather_files` in `src/sarvam_mcp/workflows/recall.py` uses `sorted(p.rglob("*"))`, which walks and sorts the whole directory tree before the `max_files` early break can fire.

So `max_files` caps the output, not the work. Point `sv_recall` at a big folder (project root with `node_modules`, a full Downloads folder) and it sorts hundreds of thousands of paths just to return 20 files. The tool is `async def` but calls this synchronously, so the event loop is blocked the whole time.

Numbers with `max_files=20`:
- 2,000 files: 0.007s
- 20,000 files: 0.088s
- 200,000 files: 0.898s

Same 20 files returned, ~125x slower.

### The fix
Drop `sorted()`, use a lazy generator + `itertools.islice` so the walk stops the moment we have `max_files` supported files.

Kept the same:
- return type `list[Path]`, cap still global across all input paths
- single-file inputs and the `_supported()` filter unchanged

One intentional change: when a folder has more supported files than `max_files`, which files get picked changes from "alphabetical first" to "walk order first". I checked the consumers (lines 62-143) — nothing depends on order (plain for loop, citations by file name not index), so this breaks nothing. If you'd rather keep the alphabetical pick, a bounded `os.walk` version is possible too — say the word.

### Tests
New `tests/test_recall_gather_bound.py`, 3 tests:
- counts how many entries the walk visits — fails on old code (walks all 505), passes on new (~20)
- cap still respected, including across multiple dirs
- single-file input unchanged

No timing asserts, so CI won't flake.

Clean venv, Python 3.12: 64 passed (61 existing + 3 new), 0 failed. Ruff clean on both changed files.

### Not doing here
The walk still runs synchronously in the handler, same as the rest of this tool's file reads. Moving that off the event loop (`asyncio.to_thread`) is a separate change — happy to follow up if you want it.