### PR TITLE
chore: migrate default STT model from saaras:v3 to saaras:v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ All defaults below reflect the latest non-deprecated models.
 
 | Tool | What it does | Default model |
 |---|---|---|
-| `sarvam_stt_transcribe` | Audio file → transcript (5 modes) | `saaras:v3` |
+| `sarvam_stt_transcribe` | Audio file → transcript (5 modes) | `saaras:v4` |
 | `sarvam_tts_speak` | Text → audio file | `bulbul:v3` |
 | `sarvam_tts_stream` | Text → streamed audio | `bulbul:v3` |
 | `sarvam_translate` | Cross-language text translate | `mayura:v1` |

--- a/scripts/probe_models.py
+++ b/scripts/probe_models.py
@@ -52,7 +52,7 @@ async def main():
     print("\n=== STT transcribe — saaras ===")
     if WAV.exists():
         wav = WAV.read_bytes()
-        for v in ["saaras:v3"]:
+        for v in ["saaras:v4", "saaras:v3"]:
             await probe(
                 v,
                 c.post_multipart(

--- a/scripts/smoke_fix.py
+++ b/scripts/smoke_fix.py
@@ -118,7 +118,7 @@ async def main():
             client.post_json(
                 "/speech-to-text/job/init",
                 json_body={
-                    "model": "saaras:v3",
+                    "model": "saaras:v4",
                     "with_timestamps": False,
                 },
             ),
@@ -135,7 +135,7 @@ async def main():
                 "/speech-to-text-batch  (multipart)",
                 client.post_multipart(
                     "/speech-to-text-batch",
-                    data={"model": "saaras:v3"},
+                    data={"model": "saaras:v4"},
                     files={"file": ("clip.wav", wav_bytes, "audio/wav")},
                 ),
             )

--- a/scripts/smoke_live.py
+++ b/scripts/smoke_live.py
@@ -325,7 +325,7 @@ async def main() -> None:
         wav_path = AUDIO_DIR / "tts_speak.wav"
         files = {"file": (wav_path.name, wav_path.read_bytes(), "audio/wav")}
         data = {
-            "model": "saaras:v3",
+            "model": "saaras:v4",
             "language_code": "hi-IN",
             "with_timestamps": "false",
             "mode": "transcribe",
@@ -393,7 +393,7 @@ async def main() -> None:
         name,
         client.post_json(
             "/speech-to-text/job/init",
-            json_body={"model": "saaras:v3", "with_timestamps": False},
+            json_body={"model": "saaras:v4", "with_timestamps": False},
         ),
     )
     if payload is not None:

--- a/src/sarvam_mcp/code/_data.py
+++ b/src/sarvam_mcp/code/_data.py
@@ -136,13 +136,13 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
     },
     "/speech-to-text": {
         "method": "POST",
-        "model": "saaras:v3 (recommended)",
+        "model": "saaras:v4 (recommended, latest)",
         "content_type": "multipart/form-data",
         "auth_header": "api-subscription-key",
         "request_body": {
             "file":              "binary, required — audio (wav, mp3, ogg, flac, m4a, webm, aac, opus, amr, wma)",
-            "model":             "str — saaras:v3",
-            "mode":              "str — transcribe (default) | translate | verbatim | translit | codemix (saaras:v3 only)",
+            "model":             "str — saaras:v4 (latest) | saaras:v3",
+            "mode":              "str — transcribe (default) | translate | verbatim | translit | codemix (saaras:v3/v4 only)",
             "language_code":     "str — BCP-47 or 'unknown' for auto-detect",
             "with_timestamps":   "bool",
             "input_audio_codec": "str (optional) — pcm_s16le | pcm_l16 | pcm_raw (required for PCM files, 16kHz only)",
@@ -155,7 +155,8 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
             "timestamps":           "list[word_ts] | null",
         },
         "notes": (
-            "Saaras v3 is the recommended model. It supports 5 output modes via the `mode` parameter. "
+            "Saaras v4 is the latest, recommended model (22 Indic languages + Global/Indian English). "
+            "It supports 5 output modes via the `mode` parameter, same as v3. "
             "For >30s audio, use /speech-to-text/job/init."
         ),
     },
@@ -173,11 +174,11 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
             "transcript":           "str — always English",
             "language_code":        "str — detected source language",
         },
-        "notes": "DEPRECATED. Migrate to /speech-to-text with model=saaras:v3 and mode=translate.",
+        "notes": "DEPRECATED. Migrate to /speech-to-text with model=saaras:v4 and mode=translate.",
     },
     "/speech-to-text/job/init": {
         "method": "POST",
-        "model": "saaras:v3 (recommended)",
+        "model": "saaras:v4 (recommended, latest)",
         "content_type": "application/json",
         "request_body": {
             "model":           "str",
@@ -308,7 +309,8 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
 # ---------------------------------------------------------------------------
 
 PRICING: dict[str, dict[str, Any]] = {
-    "saaras:v3":            {"unit": "per minute of audio",   "tier": "billed by minute (recommended)"},
+    "saaras:v4":            {"unit": "per minute of audio",   "tier": "billed by minute (recommended, latest)"},
+    "saaras:v3":            {"unit": "per minute of audio",   "tier": "billed by minute"},
     "saaras:v3-realtime":   {"unit": "per minute of audio",   "tier": "billed by minute"},
     "saaras:v2.5":          {"unit": "per minute of audio",   "tier": "billed by minute (legacy, deprecated soon)"},
     "bulbul:v3":            {"unit": "per character",         "tier": "billed by character"},

--- a/src/sarvam_mcp/code/_snippets.py
+++ b/src/sarvam_mcp/code/_snippets.py
@@ -80,14 +80,14 @@ curl -sS https://api.sarvam.ai/text-to-speech \\
 '''
 
 PY_STT = '''\
-"""Transcribe Indic audio via Saaras v3."""
+"""Transcribe Indic audio via Saaras v4."""
 import os, httpx
 
 API_KEY = os.environ["SARVAM_API_KEY"]
 
 with open("input.wav", "rb") as fh:
     files = {"file": ("input.wav", fh, "audio/wav")}
-    data  = {"model": "saaras:v3", "language_code": "hi-IN", "with_timestamps": "false"}
+    data  = {"model": "saaras:v4", "language_code": "hi-IN", "with_timestamps": "false"}
     resp = httpx.post(
         "https://api.sarvam.ai/speech-to-text",
         headers={"api-subscription-key": API_KEY},
@@ -100,7 +100,7 @@ print(resp.json()["transcript"])
 '''
 
 JS_STT = '''\
-// Transcribe Indic audio via Saaras v3.
+// Transcribe Indic audio via Saaras v4.
 import { readFileSync } from "node:fs";
 
 const API_KEY = process.env.SARVAM_API_KEY;
@@ -108,7 +108,7 @@ const wav = readFileSync("input.wav");
 
 const form = new FormData();
 form.set("file", new Blob([wav], { type: "audio/wav" }), "input.wav");
-form.set("model", "saaras:v3");
+form.set("model", "saaras:v4");
 form.set("language_code", "hi-IN");
 form.set("with_timestamps", "false");
 
@@ -126,7 +126,7 @@ CURL_STT = '''\
 curl -sS https://api.sarvam.ai/speech-to-text \\
   -H "api-subscription-key: $SARVAM_API_KEY" \\
   -F "file=@input.wav;type=audio/wav" \\
-  -F "model=saaras:v3" \\
+  -F "model=saaras:v4" \\
   -F "language_code=hi-IN" \\
   -F "with_timestamps=false" \\
   | jq .transcript

--- a/src/sarvam_mcp/code/snippets.py
+++ b/src/sarvam_mcp/code/snippets.py
@@ -149,17 +149,17 @@ def _recommend(task: str) -> dict[str, Any]:
     if re.search(r"\b(transcrib\w*|stt|speech.{0,5}to.{0,5}text|voice ?memo|voicemail\w*|recording|audio file)\b", t):
         if "english" in t or re.search(r"into english|to english", t):
             return _result(
-                model="saaras:v3",
+                model="saaras:v4",
                 endpoint="/speech-to-text",
-                why="Audio in any Indic language, output as English text — use Saaras v3 with mode='translate'.",
+                why="Audio in any Indic language, output as English text — use Saaras v4 with mode='translate'.",
                 language_code=None,
                 snippet_key=("stt", "python"),
                 extras={"mode": "translate"},
             )
         return _result(
-            model="saaras:v3",
+            model="saaras:v4",
             endpoint="/speech-to-text",
-            why="Saaras v3 is the recommended STT model (23 languages). Supports transcribe/translate/verbatim/translit/codemix modes.",
+            why="Saaras v4 is the recommended STT model (23 languages). Supports transcribe/translate/verbatim/translit/codemix modes.",
             language_code=detected_lang or "unknown",
             snippet_key=("stt", "python"),
             extras={
@@ -284,9 +284,9 @@ def _result(
 _VALID_TTS_MODELS = {"bulbul:v3"}
 _VALID_LLM_MODELS = {"sarvam-105b"}
 _VALID_TRANSLATE_MODELS = {"mayura:v1", "sarvam-translate:v1"}
-_VALID_STT_MODELS = {"saaras:v3"}
+_VALID_STT_MODELS = {"saaras:v4", "saaras:v3"}
 _VALID_STT_MODES = {"transcribe", "translate", "verbatim", "translit", "codemix"}
-_VALID_SAARAS_MODELS = {"saaras:v3", "saaras:v3-realtime", "saaras:v2.5"}
+_VALID_SAARAS_MODELS = {"saaras:v4", "saaras:v3", "saaras:v3-realtime", "saaras:v2.5"}
 _VALID_LANGUAGE_CODES = {lang["code"] for lang in _data.ALL_LANGUAGES} | {"auto", "unknown"}
 _TTS_LANG_CODES = {lang["code"] for lang in _data.LANGUAGES_BY_API["tts"]}
 
@@ -332,10 +332,10 @@ def _validate(endpoint: str, body: dict[str, Any]) -> list[dict[str, Any]]:
     elif endpoint == "/speech-to-text":
         if not body.get("file") and "file" not in body:
             issues.append(_warn("file", "Required (multipart). Pass the audio file separately."))
-        model = body.get("model", "saaras:v3")
+        model = body.get("model", "saaras:v4")
         if model not in _VALID_STT_MODELS:
             issues.append(_err("model", f"'{model}' invalid for STT.",
-                               "Use 'saaras:v3'."))
+                               "Use 'saaras:v4' (or 'saaras:v3')."))
         mode = body.get("mode")
         if mode and mode not in _VALID_STT_MODES:
             issues.append(_err("mode", f"'{mode}' invalid.",

--- a/src/sarvam_mcp/tools/stt.py
+++ b/src/sarvam_mcp/tools/stt.py
@@ -1,4 +1,4 @@
-"""Speech-to-text tools — transcribe (Saaras v3), translate (legacy), batch jobs."""
+"""Speech-to-text tools — transcribe (Saaras v4), translate (legacy), batch jobs."""
 
 from __future__ import annotations
 
@@ -22,14 +22,17 @@ STT_JOB_DOWNLOAD = f"{STT_JOB_BASE}/download-files"
 MAX_POLL_ATTEMPTS = 90
 POLL_INTERVAL_SECONDS = 2
 
-SttModel = Literal["saaras:v3"]
+SttModel = Literal["saaras:v4", "saaras:v3"]
+
+# Models whose /speech-to-text call accepts the `mode` form field.
+_MODE_CAPABLE_MODELS = {"saaras:v4", "saaras:v3"}
 
 SttMode = Literal["transcribe", "translate", "verbatim", "translit", "codemix"]
 
 InputAudioCodec = Literal["pcm_s16le", "pcm_l16", "pcm_raw"]
 
 # Legacy model types kept for the deprecated translate tool.
-SaarasModel = Literal["saaras:v3", "saaras:v3-realtime", "saaras:v2.5"]
+SaarasModel = Literal["saaras:v4", "saaras:v3", "saaras:v3-realtime", "saaras:v2.5"]
 
 
 def register(mcp: FastMCP) -> None:
@@ -37,8 +40,8 @@ def register(mcp: FastMCP) -> None:
         name="sarvam_tools_stt_transcribe",
         description=(
             "Runtime tool — calls Sarvam API now. For code-writing help, use sarvam_code_* tools.\n\n"
-            "Transcribe an audio file in any of 23 Indian languages using Saaras v3.\n\n"
-            "Saaras v3 supports multiple output modes via the `mode` parameter:\n"
+            "Transcribe an audio file in any of 23 Indian languages using Saaras v4.\n\n"
+            "Saaras v4 (like v3) supports multiple output modes via the `mode` parameter:\n"
             "  • `transcribe` (default) — standard transcription in the original language\n"
             "  • `translate` — speech from any Indic language directly to English text\n"
             "  • `verbatim` — exact word-for-word, no normalization, filler words preserved\n"
@@ -74,7 +77,7 @@ def register(mcp: FastMCP) -> None:
         mode: SttMode = Field(
             default="transcribe",
             description=(
-                "Output mode (Saaras v3 only). "
+                "Output mode (Saaras v3/v4 only). "
                 "'transcribe' (default) | 'translate' (→ English) | "
                 "'verbatim' | 'translit' (→ Roman) | 'codemix'."
             ),
@@ -83,8 +86,8 @@ def register(mcp: FastMCP) -> None:
             default=False, description="Include word-level timestamps in the response."
         ),
         model: SttModel = Field(
-            default="saaras:v3",
-            description="Saaras v3 (recommended STT model for Indic audio).",
+            default="saaras:v4",
+            description="Saaras v4 (recommended, latest STT model for Indic audio). Falls back to saaras:v3 if needed.",
         ),
         input_audio_codec: InputAudioCodec | None = Field(
             default=None,
@@ -107,10 +110,8 @@ def register(mcp: FastMCP) -> None:
                         "language_code": language_code,
                         "with_timestamps": str(with_timestamps).lower(),
                     }
-                    if model == "saaras:v3" and mode != "transcribe":
+                    if model in _MODE_CAPABLE_MODELS:
                         data["mode"] = mode
-                    elif model == "saaras:v3":
-                        data["mode"] = "transcribe"
                     if input_audio_codec is not None:
                         data["input_audio_codec"] = input_audio_codec
                     payload, call = await sc.client.post_multipart(
@@ -150,7 +151,7 @@ def register(mcp: FastMCP) -> None:
             default="saaras:v2.5",
             description=(
                 "Legacy Saaras model for the /speech-to-text-translate endpoint. "
-                "Prefer using sarvam_tools_stt_transcribe with mode='translate' and saaras:v3."
+                "Prefer using sarvam_tools_stt_transcribe with mode='translate' and saaras:v4."
             ),
         ),
     ) -> dict[str, Any]:
@@ -178,7 +179,7 @@ def register(mcp: FastMCP) -> None:
             "deprecation_notice": (
                 "This tool uses the legacy /speech-to-text-translate endpoint. "
                 "Migrate to sarvam_tools_stt_transcribe with "
-                "mode='translate' and model='saaras:v3'."
+                "mode='translate' and model='saaras:v4'."
             ),
             "observability": metrics.to_response_block(),
         }
@@ -190,7 +191,7 @@ def register(mcp: FastMCP) -> None:
             "Transcribe a long audio file (>30 s) using the batch job pipeline. "
             "Runs the full flow automatically: create job → upload audio to Azure "
             "Blob → start processing → poll until complete → return transcript.\n\n"
-            "Supports diarization, timestamps, and all Saaras v3 output modes."
+            "Supports diarization, timestamps, and all Saaras v4/v3 output modes."
         ),
     )
     async def sarvam_stt_batch_submit(
@@ -228,7 +229,7 @@ def register(mcp: FastMCP) -> None:
             default=None,
             description="Hint for diarization: expected number of speakers.",
         ),
-        model: SttModel = Field(default="saaras:v3"),
+        model: SttModel = Field(default="saaras:v4"),
     ) -> dict[str, Any]:
         sc = await ready_ctx(ctx)
         async with resolve_file_input(

--- a/src/sarvam_mcp/workflows/_helpers.py
+++ b/src/sarvam_mcp/workflows/_helpers.py
@@ -34,7 +34,7 @@ async def stt_transcribe(
     audio_path: Path,
     *,
     language_code: str = "unknown",
-    model: str = "saaras:v3",
+    model: str = "saaras:v4",
     mode: str = "transcribe",
     metrics: ToolMetrics | None = None,
 ) -> tuple[str, str | None]:
@@ -46,7 +46,7 @@ async def stt_transcribe(
             "language_code": language_code,
             "with_timestamps": "false",
         }
-        if model == "saaras:v3":
+        if model in ("saaras:v4", "saaras:v3"):
             data["mode"] = mode
         body, call = await sc.client.post_multipart("/speech-to-text", data=data, files=files)
     if metrics is not None:

--- a/tests/code/test_recommend_and_validate.py
+++ b/tests/code/test_recommend_and_validate.py
@@ -10,7 +10,7 @@ from sarvam_mcp.code.snippets import _recommend, _validate
 def test_recommend_picks_saaras_for_audio_to_english():
     result = _recommend("transcribe Hindi voicemails into English text")
     assert result["matched"]
-    assert result["recommended_model"] == "saaras:v3"
+    assert result["recommended_model"] == "saaras:v4"
     assert result["endpoint"] == "/speech-to-text"
     assert result["mode"] == "translate"
 
@@ -18,7 +18,7 @@ def test_recommend_picks_saaras_for_audio_to_english():
 def test_recommend_picks_saaras_for_indic_transcription():
     result = _recommend("transcribe Tamil customer-support calls")
     assert result["matched"]
-    assert result["recommended_model"] == "saaras:v3"
+    assert result["recommended_model"] == "saaras:v4"
     assert result["language_code"] == "ta-IN"
     assert result["mode"] == "transcribe"
 
@@ -80,7 +80,7 @@ def test_validate_tts_v3_with_v3_speaker_passes():
 def test_validate_stt_rejects_invalid_stt_model():
     issues = _validate("/speech-to-text", {"model": "stt-legacy-99"})
     assert [i for i in issues if i["field"] == "model"]
-    assert any("saaras:v3" in (i.get("fix", "") + i.get("message", "")) for i in issues)
+    assert any("saaras:v4" in (i.get("fix", "") + i.get("message", "")) for i in issues)
 
 
 def test_validate_translate_rejects_unknown_language():


### PR DESCRIPTION
Sarvam launched saaras:v4 (Epoch 2026) as the latest recommended speech-to-text model, covering Global + Indian English and 22 Indic languages. Update tool defaults, code-gen snippets/docs, and dev smoke/probe scripts to use it; saaras:v3 remains supported.