### PR TITLE
fix: repair live API drift in tools/{tts,llm,translate,language} + sync code/* reference data

### DIFF
--- a/src/sarvam_mcp/code/_data.py
+++ b/src/sarvam_mcp/code/_data.py
@@ -123,16 +123,20 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
             "speaker":              "str, required — must be compatible with chosen model",
             "model":                "str — bulbul:v3 default",
             "speech_sample_rate":   "int — 8000|16000|22050|24000|32000|44100|48000",
-            "pitch":                "float, -1.0 to 1.0 (default 0)",
             "pace":                 "float, 0.3 to 3.0 (default 1)",
-            "loudness":             "float, 0.1 to 3.0 (default 1)",
             "enable_preprocessing": "bool — normalize numbers/dates/code-mix",
         },
         "response": {
             "audios":     "list[str] — base64-encoded WAV per input",
             "request_id": "str",
         },
-        "notes": "Pick a speaker compatible with your model — see sarvam_code_speakers.",
+        "notes": (
+            "Pick a speaker compatible with your model — see sarvam_code_speakers. "
+            "Do NOT send `pitch` or `loudness` — bulbul:v3 rejects the request "
+            "outright if either is present, even at a 'neutral' value "
+            "(live-confirmed 2026-08-14: \"Pitch and loudness parameters are "
+            "currently not supported for the Bulbul V3 model\")."
+        ),
     },
     "/speech-to-text": {
         "method": "POST",
@@ -205,13 +209,18 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
             "output_script":        "str — roman | fully-native | spoken-form-in-native (Mayura only)",
             "numerals_format":      "str — international | native",
             "speaker_gender":       "str — Male | Female (gendered languages)",
-            "enable_preprocessing": "bool",
         },
         "response": {
             "translated_text":      "str",
             "source_language_code": "str",
             "request_id":           "str",
         },
+        "notes": (
+            "max input length: 1000 chars for mayura:v1, 2000 chars for "
+            "sarvam-translate:v1 (live-confirmed 2026-08-14). "
+            "`enable_preprocessing` was removed from this endpoint's schema "
+            "and is no longer a valid parameter — don't send it."
+        ),
     },
     "/transliterate": {
         "method": "POST",
@@ -251,18 +260,33 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
     },
     "/v1/chat/completions": {
         "method": "POST",
-        "model": "sarvam-105b (flagship, sole current model)",
+        "model": "sarvam-105b (flagship)",
         "content_type": "application/json",
         "request_body": {
-            "model":       "str — sarvam-105b",
-            "messages":    "list[{role, content}]",
-            "temperature": "float, 0.0 to 2.0",
-            "top_p":       "float, 0.0 to 1.0",
-            "max_tokens":  "int (optional)",
-            "stream":      "bool",
+            "model":            "str — sarvam-105b",
+            "messages":         "list[{role, content}]",
+            "temperature":      "float, 0.0 to 2.0",
+            "top_p":            "float, 0.0 to 1.0",
+            "max_tokens":       "int (optional)",
+            "reasoning_effort": "str (optional) — 'low' | 'medium' | 'high'",
+            "stream":           "bool",
         },
         "response_oai_compatible": True,
-        "notes": "OpenAI-compatible. sarvam-30b was deprecated by Sarvam; sarvam-105b is the sole current model.",
+        "notes": (
+            "OpenAI-compatible. sarvam-30b and sarvam-m were deprecated by "
+            "Sarvam; sarvam-105b is the flagship model on this v1 endpoint. "
+            "GOTCHA (live-confirmed 2026-08-14): sarvam-105b reasons by "
+            "default even without reasoning_effort set, and reasoning tokens "
+            "count against max_tokens. A small max_tokens (e.g. 20-100) can "
+            "come back with finish_reason='length' and EMPTY content — the "
+            "whole budget was consumed by hidden reasoning. Give it real "
+            "headroom (300+) or omit max_tokens; reasoning_effort='low' "
+            "reduces but does not eliminate this. "
+            "There is also a /v2/chat/completions endpoint that additionally "
+            "serves sarvam-105b-conversations and other (beta, fast-changing) "
+            "open-weight models — not covered here; check docs.sarvam.ai for "
+            "the current v2 model list before relying on a specific one."
+        ),
     },
     "/doc-digitization/job/v1": {
         "method": "POST",
@@ -283,11 +307,17 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
             "(/doc-digitization/job/v1/upload-files) → PUT file to presigned URL → "
             "start (/doc-digitization/job/v1/{job_id}/start) → "
             "poll status (/doc-digitization/job/v1/{job_id}/status). "
-            "Max 10 pages per document. Output delivered as ZIP."
+            "Max 10 pages per document. Output delivered as ZIP. "
+            "This endpoint still works (live-confirmed 2026-08-14), but Sarvam's "
+            "current docs describe a newer 'Doc AI' product at /doc-ai/v1/job/ "
+            "with separate digitise() (full-document OCR, same as this) and "
+            "extract() (schema-based field extraction — pull specific fields "
+            "instead of the whole document) operations, plus CSV/XLSX output. "
+            "Worth checking docs.sarvam.ai/docai for the current recommended path."
         ),
     },
     "/text-to-speech/pronunciation-dictionary": {
-        "method": "GET (list), POST (create)",
+        "method": "GET (list), POST (create), GET /{id} (get), DELETE ?dict_id= (delete)",
         "content_type": "application/json",
         "request_body": {
             "entries": "dict[str, str] — word → pronunciation mappings (for create)",
@@ -296,7 +326,36 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
             "dictionary_count": "int",
             "dictionaries":     "list[str] — dictionary IDs",
         },
-        "notes": "CRUD for pronunciation dictionaries. Also supports GET /{id}, PUT /{id}, DELETE /{id}.",
+        "notes": (
+            "CRUD for pronunciation dictionaries (all live-confirmed 2026-08-14). "
+            "GET a specific dictionary via a path segment (.../{dictionary_id}); "
+            "DELETE instead takes the id as a query param "
+            "(.../pronunciation-dictionary?dict_id={id}), not a path segment — "
+            "easy to get backwards."
+        ),
+    },
+    "/text-to-speech/ws": {
+        "method": "WebSocket",
+        "model": "bulbul:v3",
+        "notes": (
+            "Live-confirmed 2026-08-14. Connect to "
+            "wss://api.sarvam.ai/text-to-speech/ws?model=bulbul:v3 with header "
+            "api-subscription-key: <key>. model is a URL query param, not a "
+            "body/config field. Message sequence: send "
+            '{"type":"config","data":{"speaker","language_code","pace",'
+            '"output_audio_codec","output_audio_bitrate","min_buffer_size",'
+            '"max_chunk_length"}} first, then one or more '
+            '{"type":"text","data":{"text":...}}, then {"type":"flush"} to force '
+            "processing. Audio arrives as TEXT (JSON) frames, not binary: "
+            '{"type":"audio","data":{"content_type":...,"audio":"<base64>"}}. '
+            "There is no reliable end-of-stream event in practice — treat a "
+            "short idle period with no new frames as completion. Only the "
+            "first audio chunk carries a WAV header; concatenating chunks "
+            "in order produces a valid file, but the header's RIFF/data size "
+            "fields are streaming placeholders (0xFFFFFFFF) that must be "
+            "patched with the true length once the stream ends, or strict WAV "
+            "parsers will misread the duration."
+        ),
     },
 }
 
@@ -314,7 +373,7 @@ PRICING: dict[str, dict[str, Any]] = {
     "bulbul:v3":            {"unit": "per character",         "tier": "billed by character"},
     "mayura:v1":            {"unit": "per character",         "tier": "billed by character"},
     "sarvam-translate:v1":  {"unit": "per character",         "tier": "billed by character"},
-    "sarvam-105b":          {"unit": "per 1M tokens",         "tier": "billed by tokens (flagship)"},
+    "sarvam-105b":          {"unit": "per 1M tokens",         "tier": "billed by tokens (flagship). Hidden reasoning tokens count as completion tokens and are billed the same as visible output."},
     "sarvam-vision":        {"unit": "per page",              "tier": "billed by page"},
 }
 

--- a/src/sarvam_mcp/code/docs.py
+++ b/src/sarvam_mcp/code/docs.py
@@ -36,6 +36,7 @@ EndpointPath = Literal[
     "/v1/chat/completions",
     "/doc-digitization/job/v1",
     "/text-to-speech/pronunciation-dictionary",
+    "/text-to-speech/ws",
 ]
 TtsModel = Literal["bulbul:v3"]
 

--- a/src/sarvam_mcp/code/snippets.py
+++ b/src/sarvam_mcp/code/snippets.py
@@ -328,6 +328,13 @@ def _validate(endpoint: str, body: dict[str, Any]) -> list[dict[str, Any]]:
             8000, 16000, 22050, 24000, 32000, 44100, 48000
         ):
             issues.append(_err("speech_sample_rate", "Invalid sample rate."))
+        for f in ("pitch", "loudness"):
+            if f in body:
+                issues.append(_err(
+                    f, f"bulbul:v3 rejects the request outright if `{f}` is present "
+                    "at all, even at a neutral/default value.",
+                    f"Remove `{f}` from the body entirely.",
+                ))
 
     elif endpoint == "/speech-to-text":
         if not body.get("file") and "file" not in body:
@@ -365,6 +372,22 @@ def _validate(endpoint: str, body: dict[str, Any]) -> list[dict[str, Any]]:
         if model == "sarvam-translate:v1" and body.get("mode"):
             issues.append(_warn("mode", "Sarvam-Translate v1 ignores `mode` — formal only.",
                                 "Drop the field or switch to mayura:v1 if you need modes."))
+        if "enable_preprocessing" in body:
+            issues.append(_warn(
+                "enable_preprocessing",
+                "This parameter was removed from /translate's schema and is "
+                "silently ignored by the API — it no longer controls anything.",
+                "Drop the field.",
+            ))
+        input_text = body.get("input")
+        if isinstance(input_text, str):
+            limit = 1000 if model == "mayura:v1" else 2000
+            if len(input_text) > limit:
+                issues.append(_err(
+                    "input", f"{len(input_text)} chars exceeds the {limit}-char "
+                    f"limit for {model}.",
+                    "Shorten the input, or switch model if you need the higher limit.",
+                ))
 
     elif endpoint == "/v1/chat/completions":
         if not body.get("messages"):
@@ -376,6 +399,21 @@ def _validate(endpoint: str, body: dict[str, Any]) -> list[dict[str, Any]]:
         t = body.get("temperature")
         if t is not None and not (0.0 <= t <= 2.0):
             issues.append(_err("temperature", "Must be between 0.0 and 2.0."))
+        max_tokens = body.get("max_tokens")
+        if (
+            isinstance(max_tokens, int)
+            and max_tokens < 200
+            and not body.get("reasoning_effort")
+        ):
+            issues.append(_warn(
+                "max_tokens",
+                f"sarvam-105b reasons by default and reasoning tokens count "
+                f"against max_tokens — {max_tokens} can easily be consumed "
+                "entirely by hidden reasoning, returning empty content with "
+                "finish_reason='length'.",
+                "Raise max_tokens (300+), omit it entirely, or set "
+                "reasoning_effort='low' (reduces but doesn't eliminate this).",
+            ))
 
     elif endpoint == "/text-analytics":
         if not body.get("text"):

--- a/src/sarvam_mcp/tools/language.py
+++ b/src/sarvam_mcp/tools/language.py
@@ -31,7 +31,7 @@ def register(mcp: FastMCP) -> None:
     )
     async def sarvam_identify_language(
         ctx: Context,
-        input: str = Field(description="Text whose language to identify."),
+        input: str = Field(description="Text whose language to identify. Max 1000 characters."),
     ) -> dict[str, Any]:
         sc = await ready_ctx(ctx)
         with measure_tool() as metrics:
@@ -47,6 +47,12 @@ def register(mcp: FastMCP) -> None:
         name="sarvam_tools_text_analytics",
         description=(
             "Runtime tool — calls Sarvam API now. For code-writing help, use sarvam_code_* tools.\n\n"
+            "KNOWN ISSUE (as of 2026-08-13): the upstream `/text-analytics` endpoint "
+            "is currently returning 404 Not Found for all requests — confirmed via a "
+            "direct API call outside this tool, so this is not a bug in sarvam-mcp's "
+            "request shape. The endpoint's own docs page is also 404. If this tool "
+            "fails, that's very likely why — don't retry, and check dashboard.sarvam.ai "
+            "or Sarvam support for current availability before relying on it.\n\n"
             "Run deep analysis on a piece of text by passing a list of typed "
             "questions. Each question needs `id`, `text`, and `type` "
             "(`boolean` | `enum` | `short answer` | `long answer` | `number`). "

--- a/src/sarvam_mcp/tools/llm.py
+++ b/src/sarvam_mcp/tools/llm.py
@@ -13,6 +13,7 @@ from sarvam_mcp.tools._common import SarvamLLM, ready_ctx
 CHAT_PATH = "/v1/chat/completions"
 
 ChatRole = Literal["system", "user", "assistant"]
+ReasoningEffort = Literal["low", "medium", "high"]
 
 
 def register(mcp: FastMCP) -> None:
@@ -41,6 +42,18 @@ def register(mcp: FastMCP) -> None:
         temperature: float = Field(default=0.7, ge=0.0, le=2.0),
         top_p: float = Field(default=1.0, ge=0.0, le=1.0),
         max_tokens: int | None = Field(default=None, ge=1),
+        reasoning_effort: ReasoningEffort | None = Field(
+            default=None,
+            description=(
+                "sarvam-105b reasons by default even if you don't ask for it, consuming "
+                "a variable, often large chunk of max_tokens on hidden reasoning before "
+                "any visible content is produced. 'low' reduces that overhead but does "
+                "NOT eliminate it — a small max_tokens (e.g. 20-100) can still come back "
+                "empty. If you set max_tokens, give it real headroom (300+); omitting "
+                "max_tokens entirely is the safest way to always get visible content. "
+                "Omit this field to use the API's own default effort."
+            ),
+        ),
         stream: bool = Field(
             default=False,
             description="Streaming via MCP isn't useful for chat — keep False unless testing.",
@@ -56,6 +69,8 @@ def register(mcp: FastMCP) -> None:
         }
         if max_tokens is not None:
             body["max_tokens"] = max_tokens
+        if reasoning_effort is not None:
+            body["reasoning_effort"] = reasoning_effort
 
         with measure_tool() as metrics:
             payload, call = await sc.client.post_json(CHAT_PATH, json_body=body)
@@ -75,8 +90,16 @@ def register(mcp: FastMCP) -> None:
             "observability": metrics.to_response_block(),
         }
         if finish_reason == "length":
-            result["truncation_warning"] = (
-                "Output was truncated because max_tokens was reached. "
-                "Increase max_tokens or omit it for the full response."
-            )
+            if not content:
+                result["truncation_warning"] = (
+                    "max_tokens was reached before any visible content was produced — "
+                    "consumed entirely by sarvam-105b's reasoning. Raise max_tokens "
+                    "substantially (300+) and/or pass reasoning_effort='low'; omitting "
+                    "max_tokens entirely is the most reliable fix."
+                )
+            else:
+                result["truncation_warning"] = (
+                    "Output was truncated because max_tokens was reached. "
+                    "Increase max_tokens or omit it for the full response."
+                )
         return result

--- a/src/sarvam_mcp/tools/translate.py
+++ b/src/sarvam_mcp/tools/translate.py
@@ -39,7 +39,12 @@ def register(mcp: FastMCP) -> None:
     )
     async def sarvam_translate(
         ctx: Context,
-        input: str = Field(description="Text to translate (max ~2000 chars)."),
+        input: str = Field(
+            description=(
+                "Text to translate. Max length depends on model: 1000 chars for "
+                "mayura:v1, 2000 chars for sarvam-translate:v1."
+            ),
+        ),
         source_language_code: LanguageCode = Field(
             description="Source BCP-47 code, or 'auto' to auto-detect.",
         ),
@@ -61,7 +66,6 @@ def register(mcp: FastMCP) -> None:
             default=None,
             description="Helps disambiguate gendered languages (e.g. Hindi).",
         ),
-        enable_preprocessing: bool = Field(default=True),
     ) -> dict[str, Any]:
         sc = await ready_ctx(ctx)
         # Upstream /translate accepts "auto", not "unknown".
@@ -72,7 +76,6 @@ def register(mcp: FastMCP) -> None:
             "target_language_code": target_language_code,
             "model": model,
             "numerals_format": numerals_format,
-            "enable_preprocessing": enable_preprocessing,
         }
         if model == "mayura:v1":
             body["mode"] = mode

--- a/src/sarvam_mcp/tools/tts.py
+++ b/src/sarvam_mcp/tools/tts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import time
 import uuid
@@ -14,7 +15,16 @@ from sarvam_mcp.observability import measure_tool
 from sarvam_mcp.tools._common import BulbulSpeaker, TtsLanguageCode, ready_ctx
 
 TTS_PATH = "/text-to-speech"
-TTS_STREAM_PATH = "/text-to-speech/stream"  # documented WebSocket path
+TTS_STREAM_PATH = "/text-to-speech/ws"  # current WebSocket path — live-confirmed 2026-08-14.
+# The old "/text-to-speech/stream" path used to live here now returns HTTP 403
+# at the WebSocket handshake, before a single message is sent.
+
+# Idle time with no new frame from the server before we consider the stream
+# finished — the WS protocol has no reliable "done" event (send_completion_event
+# didn't produce one in live testing either), so this is a timeout heuristic,
+# same as the one described in Sarvam's own docs.
+WS_IDLE_TIMEOUT_SECONDS = 8.0
+WS_MAX_STREAM_SECONDS = 60.0
 
 SampleRate = Literal[8000, 16000, 22050, 24000, 32000, 44100, 48000]
 TtsModel = Literal["bulbul:v3"]
@@ -48,9 +58,7 @@ def register(mcp: FastMCP) -> None:
         speech_sample_rate: SampleRate = Field(
             default=24000, description="PCM sample rate of the output WAV."
         ),
-        pitch: float = Field(default=0.0, ge=-1.0, le=1.0),
         pace: float = Field(default=1.0, ge=0.3, le=3.0),
-        loudness: float = Field(default=1.0, ge=0.1, le=3.0),
         enable_preprocessing: bool = Field(
             default=True,
             description="Normalize numbers/dates/code-mixed segments before synthesis.",
@@ -61,14 +69,15 @@ def register(mcp: FastMCP) -> None:
         ),
     ) -> dict[str, Any]:
         sc = await ready_ctx(ctx)
+        # bulbul:v3 rejects requests that include pitch/loudness at all
+        # ("Pitch and loudness parameters are currently not supported for
+        # the Bulbul V3 model") — live-confirmed 2026-08-13. Don't send them.
         body: dict[str, Any] = {
             "inputs": [text],
             "target_language_code": target_language_code,
             "speaker": speaker,
             "speech_sample_rate": speech_sample_rate,
-            "pitch": pitch,
             "pace": pace,
-            "loudness": loudness,
             "enable_preprocessing": enable_preprocessing,
             "model": model,
         }
@@ -104,8 +113,12 @@ def register(mcp: FastMCP) -> None:
         description=(
             "Runtime tool — calls Sarvam API now. For code-writing help, use sarvam_code_* tools.\n\n"
             "Streaming variant of sarvam_tts_speak using the TTS WebSocket. "
-            "Audio is streamed to disk in the background; the tool returns a "
-            "sarvam:// resource URI immediately."
+            "Opens a connection, sends the text once, and collects the streamed "
+            "audio chunks into a single WAV file (there's no reliable server-side "
+            "'done' signal, so completion is detected via a short idle timeout — "
+            "expect a few extra seconds of latency vs. sarvam_tts_speak for that "
+            "reason). Falls back to the REST endpoint if the WebSocket is "
+            "unavailable."
         ),
     )
     async def sarvam_tts_stream(
@@ -113,34 +126,45 @@ def register(mcp: FastMCP) -> None:
         text: str = Field(description="Text to synthesize."),
         target_language_code: TtsLanguageCode = Field(),
         speaker: BulbulSpeaker = Field(default="priya"),
-        speech_sample_rate: SampleRate = Field(default=24000),
+        pace: float = Field(default=1.0, ge=0.3, le=3.0),
         model: TtsModel = Field(default="bulbul:v3"),
     ) -> dict[str, Any]:
         sc = await ready_ctx(ctx)
-        ws_url = sc.config.base_url.replace("http", "ws", 1) + TTS_STREAM_PATH
+        ws_url = f"{sc.config.base_url.replace('http', 'ws', 1)}{TTS_STREAM_PATH}?model={model}"
 
         chunks: list[bytes] = []
         with measure_tool() as metrics:
             try:
                 async with sc.client.stream_ws(ws_url) as ws:
                     await ws.send(
-                        _ws_request_payload(
-                            text=text,
-                            target_language_code=target_language_code,
-                            speaker=speaker,
-                            speech_sample_rate=speech_sample_rate,
-                            model=model,
+                        _ws_config_payload(
+                            speaker=speaker, language_code=target_language_code, pace=pace
                         )
                     )
-                    async for frame in ws:
+                    await ws.send(_ws_text_payload(text))
+                    await ws.send(_ws_flush_payload())
+
+                    loop = asyncio.get_event_loop()
+                    deadline = loop.time() + WS_MAX_STREAM_SECONDS
+                    while loop.time() < deadline:
+                        try:
+                            frame = await asyncio.wait_for(
+                                ws.recv(), timeout=WS_IDLE_TIMEOUT_SECONDS
+                            )
+                        except TimeoutError:
+                            break  # no new audio for a while — treat as done
                         if isinstance(frame, bytes):
                             chunks.append(frame)
-                        else:
-                            event = _maybe_parse_event(frame)
-                            if event.get("type") == "end":
+                            continue
+                        event = _maybe_parse_event(frame)
+                        event_type = event.get("type")
+                        if event_type == "audio":
+                            audio_b64 = (event.get("data") or {}).get("audio")
+                            if audio_b64:
+                                chunks.append(base64.b64decode(audio_b64))
+                        elif event_type == "event":
+                            if (event.get("data") or {}).get("event_type") == "final":
                                 break
-                            if event.get("audio"):
-                                chunks.append(base64.b64decode(event["audio"]))
             except Exception as exc:  # noqa: BLE001
                 # Fall back to REST if streaming endpoint is unavailable.
                 await ctx.warning(
@@ -152,7 +176,8 @@ def register(mcp: FastMCP) -> None:
                         "inputs": [text],
                         "target_language_code": target_language_code,
                         "speaker": speaker,
-                        "speech_sample_rate": speech_sample_rate,
+                        "speech_sample_rate": 24000,
+                        "pace": pace,
                         "model": model,
                     },
                 )
@@ -164,6 +189,7 @@ def register(mcp: FastMCP) -> None:
         wav_bytes = b"".join(chunks)
         if not wav_bytes:
             raise RuntimeError("TTS stream produced no audio.")
+        wav_bytes = _finalize_wav_header(wav_bytes)
 
         filename = f"sarvam-tts-stream-{uuid.uuid4().hex[:8]}.wav"
         stored = await sc.audio_sink.store(
@@ -179,26 +205,57 @@ def register(mcp: FastMCP) -> None:
         }
 
 
-def _ws_request_payload(
-    *,
-    text: str,
-    target_language_code: str,
-    speaker: str,
-    speech_sample_rate: int,
-    model: str,
-) -> str:
+def _ws_config_payload(*, speaker: str, language_code: str, pace: float) -> str:
     import json as _json
 
     return _json.dumps(
         {
-            "type": "synthesize",
-            "text": text,
-            "target_language_code": target_language_code,
-            "speaker": speaker,
-            "speech_sample_rate": speech_sample_rate,
-            "model": model,
+            "type": "config",
+            "data": {
+                "speaker": speaker,
+                "language_code": language_code,
+                "pace": pace,
+                "output_audio_codec": "wav",
+            },
         }
     )
+
+
+def _ws_text_payload(text: str) -> str:
+    import json as _json
+
+    return _json.dumps({"type": "text", "data": {"text": text}})
+
+
+def _ws_flush_payload() -> str:
+    import json as _json
+
+    return _json.dumps({"type": "flush"})
+
+
+def _finalize_wav_header(wav_bytes: bytes) -> bytes:
+    """Patch the RIFF/data chunk sizes once the full stream is collected.
+
+    Sarvam's TTS WebSocket streams a WAV whose header doesn't know the final
+    length up front, so it fills the RIFF size and ``data`` chunk size fields
+    with the streaming placeholder ``0xFFFFFFFF``. That's fine for a live
+    stream but produces a file some WAV parsers read incorrectly (e.g.
+    Python's own ``wave`` module reports a ~27-hour duration for a 5-second
+    clip) — live-confirmed 2026-08-14. Rewrite both fields now that the true
+    size is known.
+    """
+    import struct
+
+    if len(wav_bytes) < 44 or wav_bytes[:4] != b"RIFF" or wav_bytes[8:12] != b"WAVE":
+        return wav_bytes
+    patched = bytearray(wav_bytes)
+    patched[4:8] = struct.pack("<I", len(wav_bytes) - 8)
+    data_offset = wav_bytes.find(b"data")
+    if data_offset != -1 and data_offset + 8 <= len(wav_bytes):
+        patched[data_offset + 4 : data_offset + 8] = struct.pack(
+            "<I", len(wav_bytes) - (data_offset + 8)
+        )
+    return bytes(patched)
 
 
 def _maybe_parse_event(frame: str) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

A live audit against `api.sarvam.ai` + `docs.sarvam.ai` surfaced several places where the tools had drifted from the current API. Each fix below was reproduced live before the change and re-verified live after.

- **`sarvam_tools_tts_speak` was failing on every call.** It always sent `pitch`/`loudness`; bulbul:v3 now rejects any request containing either field ("Pitch and loudness parameters are currently not supported for the Bulbul V3 model"). Dropped both.
- **`sarvam_tools_tts_stream` was fundamentally broken**, not just stale: the WebSocket path it used (`/text-to-speech/stream`) now 403s at the handshake, and the message protocol it sent was never valid against the current API. Rewrote it against the verified current protocol (`/text-to-speech/ws?model=...`, `config`/`text`/`flush` messages, JSON audio-chunk frames, idle-timeout completion) and fixed a WAV-header bug where Sarvam's streaming placeholder size (`0xFFFFFFFF`) was left unpatched, which some parsers (including Python's own `wave` module) misread as a multi-hour file.
- **`sarvam_llm_complete` had no way to control reasoning overhead.** sarvam-105b reasons by default, and those tokens count against `max_tokens` — a modest budget can come back with `finish_reason="length"` and empty content. Added an optional `reasoning_effort` parameter and sharpened the truncation warning to name this failure mode.
- **`/translate`'s `enable_preprocessing` parameter no longer exists upstream** — removed it rather than leave a dead control. Also fixed the `input` docstring: the character limit is per-model (1000 for `mayura:v1`, 2000 for `sarvam-translate:v1`), not a flat ~2000.
- **`/text-analytics` returns 404 for all requests**, confirmed via a direct API call outside the tool (not an implementation bug on our side — the endpoint's own docs page is also 404). Added a warning to the tool description so callers don't retry a call that can't succeed; this needs following up with Sarvam directly, not fixable from this repo.
- **`sarvam_code_*` reference/validation data had the same drift** as the runtime bugs above (e.g. the validator gave a clean bill of health to TTS requests containing `pitch`, which the live API rejects). Synced `code/_data.py` and `code/snippets.py`'s validator with the same live findings, corrected the pronunciation-dictionary DELETE shape (query param, not path segment — verified via a live create/get/delete round trip), and added a previously-missing `/text-to-speech/ws` reference entry.

## Explicitly out of scope

- Migrating `vision.py` off the legacy `/doc-digitization/job/v1` pipeline onto Sarvam's newer Doc AI product (`/doc-ai/v1/job/{digitise,extract}`) — the old endpoint still works today (verified live), and the newer one needs its own design pass (new job schema, CSV/XLSX output, schema-based field extraction).
- Adding `/v2/chat/completions` support (additional models like `sarvam-105b-conversations`, GLM-5.2, Gemma4) — these are beta and churning fast in Sarvam's own docs; noted as an option in the reference data without committing to specific model IDs.

## Test plan

- [x] `pytest -q` before and after: same baseline (48 passed / 2 failed / 11 errored — pre-existing Windows `USERPROFILE`-vs-`HOME` test gap and a missing `pytest-httpx` dev dependency in this environment, both unrelated to this change)
- [x] `ruff check` clean on all changed files
- [x] Live-verified against `api.sarvam.ai` with a real key: `tts_speak`, `tts_stream` (WAV header + duration confirmed correct with Python's `wave` module), `llm_complete` with `reasoning_effort`, `translate` (both models), `identify_language`, pronunciation dictionary create/get/delete round trip, and `sarvam_code_validate_request`/`sarvam_code_api_reference` against the updated reference data