### PR TITLE
fix: reject filenames that escape base_path in FileSink.store

### DIFF
--- a/src/sarvam_mcp/audio/sinks.py
+++ b/src/sarvam_mcp/audio/sinks.py
@@ -37,7 +37,10 @@ class FileSink:
 
     async def store(self, data: bytes, *, filename: str, mime_type: str) -> StoredAudio:
         self._base_path.mkdir(parents=True, exist_ok=True)
-        path = self._base_path / filename
+        base = self._base_path.resolve()
+        path = (base / filename).resolve()
+        if not path.is_relative_to(base):
+            raise ValueError(f"filename escapes base path: {filename!r}")
         path.write_bytes(data)
         return StoredAudio(
             file_path=str(path),

--- a/tests/test_audio_sinks.py
+++ b/tests/test_audio_sinks.py
@@ -51,6 +51,27 @@ async def test_both_sink_writes_and_returns_resource(tmp_base_path):
     assert (tmp_base_path / "x.wav").read_bytes() == SAMPLE
 
 
+async def test_file_sink_rejects_traversal_filename(tmp_base_path):
+    sink = FileSink(tmp_base_path)
+    with pytest.raises(ValueError, match="escapes base path"):
+        await sink.store(SAMPLE, filename="../escape.wav", mime_type="audio/wav")
+    assert not (tmp_base_path.parent / "escape.wav").exists()
+
+
+async def test_file_sink_rejects_absolute_filename(tmp_base_path, tmp_path):
+    sink = FileSink(tmp_base_path)
+    outside = tmp_path / "outside.wav"
+    with pytest.raises(ValueError, match="escapes base path"):
+        await sink.store(SAMPLE, filename=str(outside), mime_type="audio/wav")
+    assert not outside.exists()
+
+
+async def test_file_sink_allows_plain_filename_after_guard(tmp_base_path):
+    sink = FileSink(tmp_base_path)
+    result = await sink.store(SAMPLE, filename="ok.wav", mime_type="audio/wav")
+    assert result.file_path == str((tmp_base_path / "ok.wav").resolve())
+
+
 def test_build_sink_dispatch(tmp_base_path):
     assert isinstance(build_sink("files", tmp_base_path), FileSink)
     assert isinstance(build_sink("resources", tmp_base_path), ResourceSink)


### PR DESCRIPTION
Fixes #74.

## What

`FileSink.store()` joined `base_path` with the caller-supplied `filename` and wrote there with no containment check. A `filename` containing `../` segments would resolve outside `base_path`, and an absolute `filename` would discard `base_path` entirely (pathlib `/` operator behavior).

This PR resolves the joined path and raises `ValueError` if it does not stay under `base_path`:

```python
base = self._base_path.resolve()
path = (base / filename).resolve()
if not path.is_relative_to(base):
    raise ValueError(f"filename escapes base path: {filename!r}")
```

As noted in the issue, all current callers generate filenames internally via `uuid.uuid4()`, so this is not exploitable today; the guard is defense in depth so a future "let me choose the output filename" feature cannot silently become an arbitrary file write. `BothSink` delegates to `FileSink`, so both sinks are covered by the single check.

## Tests

Added to `tests/test_audio_sinks.py`:

- `../escape.wav` raises and writes nothing outside `base_path`
- an absolute path raises and writes nothing at the target
- a plain filename still stores normally

`pytest -q`: 64 passed. `ruff check` and `ruff format --check` are clean on both changed files (the repo-wide ruff failures on `scripts/` and `tools/` pre-exist on `main` with recent ruff versions and are untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)