### PR TITLE
Validate base64 payloads before sending to Sarvam APIs

### DIFF
--- a/src/sarvam_mcp/tools/_common.py
+++ b/src/sarvam_mcp/tools/_common.py
@@ -7,6 +7,7 @@ so tool modules can stay short and focused on their endpoint shape.
 from __future__ import annotations
 
 import base64
+import binascii
 import tempfile
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -55,16 +56,23 @@ async def resolve_file_input(
     if filename:
         suffix = Path(filename).suffix or ""
 
+    decoded_data: bytes | None = None
+    if file_base64 is not None:
+        try:
+            decoded_data = base64.b64decode(file_base64, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError("Invalid base64 file data.") from exc
+        if len(decoded_data) > max_bytes:
+            raise ValueError(
+                f"Decoded file is {len(decoded_data)} bytes, exceeds {max_bytes} byte limit."
+            )
+
     tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
     tmp_path = Path(tmp.name)
     try:
         if file_base64 is not None:
-            data = base64.b64decode(file_base64)
-            if len(data) > max_bytes:
-                raise ValueError(
-                    f"Decoded file is {len(data)} bytes, exceeds {max_bytes} byte limit."
-                )
-            tmp.write(data)
+            assert decoded_data is not None
+            tmp.write(decoded_data)
             tmp.close()
             yield tmp_path
         else:

--- a/tests/tools/test_file_input_validation.py
+++ b/tests/tools/test_file_input_validation.py
@@ -1,0 +1,48 @@
+"""Validation tests for remote file inputs."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from sarvam_mcp.tools import _common
+from sarvam_mcp.tools._common import resolve_file_input
+
+
+@pytest.mark.parametrize(
+    "encoded",
+    [
+        "!!!!",
+        "aGVsbG8=!!!!",
+        "a===",
+    ],
+)
+async def test_resolve_file_input_rejects_malformed_base64(encoded: str) -> None:
+    with pytest.raises(ValueError, match="Invalid base64 file data"):
+        async with resolve_file_input(file_base64=encoded, filename="audio.wav"):
+            pass
+
+
+async def test_resolve_file_input_accepts_valid_base64() -> None:
+    content = b"valid audio bytes"
+    encoded = base64.b64encode(content).decode("ascii")
+
+    async with resolve_file_input(file_base64=encoded, filename="audio.wav") as path:
+        assert path.suffix == ".wav"
+        assert path.read_bytes() == content
+
+    assert not path.exists()
+
+
+async def test_resolve_file_input_validates_before_creating_temp_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("temporary file created for invalid base64")
+
+    monkeypatch.setattr(_common.tempfile, "NamedTemporaryFile", fail_if_called)
+
+    with pytest.raises(ValueError, match="Invalid base64 file data"):
+        async with resolve_file_input(file_base64="!!!!", filename="audio.wav"):
+            pass


### PR DESCRIPTION
Fixes #80 

## Summary

Make remote file input validation reject malformed base64 payloads instead of silently decoding them into empty or corrupted files.

## Problem

`resolve_file_input` used Python's permissive `base64.b64decode()` behavior. Inputs containing invalid characters could therefore be accepted:

```python
base64.b64decode("!!!!")
# b""

base64.b64decode("aGVsbG8=!!!!")
# b"hello"
```

Because this helper is shared by STT, Vision, Voice, Dub, and Recall, malformed input could reach several Sarvam APIs and produce misleading upstream errors.

## Changes

- Decode base64 input with `validate=True`.
- Convert `binascii.Error` and decoding-related `ValueError` exceptions into a clear `ValueError("Invalid base64 file data.")`.
- Perform decoding and decoded-size validation before allocating a temporary file.
- Preserve the existing decoded-size limit and successful-input behavior.
- Add focused regression tests for:
  - input containing only invalid characters;
  - trailing junk after base64 padding;
  - invalid padding;
  - valid base64 decoding and filename extension preservation;
  - ensuring malformed input does not create a temporary file.

## Why validate before creating the temporary file?

Malformed input does not need filesystem resources. Rejecting it first also keeps this change independent of the Windows temporary-file handle cleanup tracked in #59 and #73.

## Testing

```text
66 passed in 5.56s
```
<img width="800" height="79" alt="image" src="https://github.com/user-attachments/assets/7a53dcfe-731f-4272-b67f-2f6e953e5186" />


Focused test command:

```bash
pytest -q tests/tools/test_file_input_validation.py
```

Full test command:

```bash
pytest -q
```

The local server was also started through the MCP Python SDK and completed an authenticated stdio handshake:

```text
server_name=sarvam-mcp
tools_count=30
validation_surface_present=True
```

An end-to-end call to `sarvam_tools_stt_transcribe` with `audio_base64="!!!!"` returned an MCP tool error containing `Invalid base64 file data.` No Sarvam API request is made for this invalid input.
<img width="1872" height="1450" alt="image" src="https://github.com/user-attachments/assets/88018b3e-9c26-4974-bfee-a69e54311e01" />


The new test file passes both required Ruff checks:

```bash
ruff check tests/tools/test_file_input_validation.py
ruff format --check tests/tools/test_file_input_validation.py
```
