### PR TITLE
fix: make config tests cross-platform on Windows (use USERPROFILE, not just HOME)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,8 +15,18 @@ def _write_creds(home: Path, body: str) -> None:
     (sarvam_dir / "credentials").write_text(body)
 
 
-def test_credentials_file_parses_quoted_and_comments(tmp_path, monkeypatch):
+def _set_home(monkeypatch, tmp_path: Path) -> None:
+    """Point ``~`` at tmp_path for Path.expanduser() on both POSIX and Windows.
+
+    ``expanduser()`` reads HOME on POSIX but USERPROFILE (not HOME) on Windows,
+    so both must be set for these tests to be platform-independent.
+    """
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+
+def test_credentials_file_parses_quoted_and_comments(tmp_path, monkeypatch):
+    _set_home(monkeypatch, tmp_path)
     _write_creds(
         tmp_path,
         '# leading comment\napi_key = "sk_quoted"\n\n  ignored line\n',
@@ -27,14 +37,14 @@ def test_credentials_file_parses_quoted_and_comments(tmp_path, monkeypatch):
 
 
 def test_invalid_output_mode_raises(monkeypatch, tmp_path):
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _set_home(monkeypatch, tmp_path)
     monkeypatch.setenv("SARVAM_AUDIO_OUTPUT_MODE", "magic")
     with pytest.raises(ValueError, match="SARVAM_AUDIO_OUTPUT_MODE"):
         Config.load()
 
 
 def test_base_path_expands(monkeypatch, tmp_path):
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _set_home(monkeypatch, tmp_path)
     target = tmp_path / "out"
     monkeypatch.setenv("SARVAM_MCP_BASE_PATH", str(target))
     cfg = Config.load()
@@ -42,14 +52,14 @@ def test_base_path_expands(monkeypatch, tmp_path):
 
 
 def test_api_key_from_env(monkeypatch, tmp_path):
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _set_home(monkeypatch, tmp_path)
     monkeypatch.setenv("SARVAM_API_KEY", "sk_from_env")
     cfg = Config.load()
     assert cfg.api_key == "sk_from_env"
 
 
 def test_api_key_from_credentials(tmp_path, monkeypatch):
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _set_home(monkeypatch, tmp_path)
     monkeypatch.delenv("SARVAM_API_KEY", raising=False)
     _write_creds(tmp_path, "api_key = sk_from_file\n")
     cfg = Config.load()


### PR DESCRIPTION
## Problem
The tests in `tests/test_config.py` set a fake home directory using only the
`HOME` environment variable. On Windows, `Path.expanduser()` resolves `~` from
`USERPROFILE`, not `HOME`, so the fake home is ignored — `~/.sarvam/credentials`
resolves to the developer's real home directory, and the affected tests fail.

To be clear, this is a **test-only** issue: the runtime code
(`auth/elicit.py`) already works correctly on Windows because `expanduser()`
resolves properly there. Only the test setup was written in a Linux/macOS-only
way, so the test suite fails for anyone developing on Windows.

This went unnoticed because CI only runs on `ubuntu-latest`, even though the
README and AGENTS.md state the package supports Windows.

## Fix
- Set both `HOME` and `USERPROFILE` when pointing tests at a temp home dir, so
  the fake home is respected on every OS.
- Add `windows-latest` to the CI test matrix so this class of regression is
  caught automatically in future and the documented Windows support is verified.

## Testing
- `pytest -q` → all tests pass on Windows (previously 2 failed).
- `ruff check .` and `ruff format --check .` are clean.