### PR TITLE
fix(code): sync batch STT builder docs with runtime API (fixes #83)

### DIFF
--- a/src/sarvam_mcp/code/_data.py
+++ b/src/sarvam_mcp/code/_data.py
@@ -161,7 +161,7 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
         "notes": (
             "Saaras v4 is the latest, recommended model (22 Indic languages + Global/Indian English). "
             "It supports 5 output modes via the `mode` parameter, same as v3. "
-            "For >30s audio, use /speech-to-text/job/init."
+            "For >30s audio, use /speech-to-text/job/v1."
         ),
     },
     "/speech-to-text-translate": {
@@ -180,22 +180,26 @@ API_REFERENCE: dict[str, dict[str, Any]] = {
         },
         "notes": "DEPRECATED. Migrate to /speech-to-text with model=saaras:v4 and mode=translate.",
     },
-    "/speech-to-text/job/init": {
+    "/speech-to-text/job/v1": {
         "method": "POST",
         "model": "saaras:v4 (recommended, latest)",
         "content_type": "application/json",
+        "auth_header": "api-subscription-key",
         "request_body": {
-            "model":           "str",
-            "with_timestamps": "bool",
-            "language_code":   "str (optional)",
+            "job_parameters": "object — {model, mode, language_code, with_timestamps, with_diarization, num_speakers}",
         },
         "response": {
-            "job_id":                  "str",
-            "input_storage_path":      "str — Azure Blob SAS URL (PUT audio here)",
-            "output_storage_path":     "str — Azure Blob SAS URL (poll for results)",
-            "storage_container_type":  "str — 'Azure'",
+            "job_id": "str",
         },
-        "notes": "Async batch flow: init -> upload to SAS -> poll /speech-to-text/job/status?job_id=...",
+        "notes": (
+            "Async batch flow for audio >30s: create job (this endpoint) → "
+            "get upload URLs (/speech-to-text/job/v1/upload-files) → "
+            "PUT audio to the returned SAS URL → "
+            "start (/speech-to-text/job/v1/{job_id}/start) → "
+            "poll status (GET /speech-to-text/job/v1/{job_id}/status) → "
+            "read the transcript from status or download-files. "
+            "SAS URLs are not returned by create."
+        ),
     },
     "/translate": {
         "method": "POST",

--- a/src/sarvam_mcp/code/docs.py
+++ b/src/sarvam_mcp/code/docs.py
@@ -27,7 +27,7 @@ ApiName = Literal[
 EndpointPath = Literal[
     "/speech-to-text",
     "/speech-to-text-translate",
-    "/speech-to-text/job/init",
+    "/speech-to-text/job/v1",
     "/text-to-speech",
     "/translate",
     "/transliterate",

--- a/src/sarvam_mcp/code/snippets.py
+++ b/src/sarvam_mcp/code/snippets.py
@@ -164,7 +164,7 @@ def _recommend(task: str) -> dict[str, Any]:
             snippet_key=("stt", "python"),
             extras={
                 "mode": "transcribe",
-                "tip_long_audio": "For audio >30s, use /speech-to-text/job/init for the async batch flow.",
+                "tip_long_audio": "For audio >30s, use /speech-to-text/job/v1 for the async batch flow.",
             },
         )
 

--- a/tests/code/test_data.py
+++ b/tests/code/test_data.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from sarvam_mcp.code import _data
+from sarvam_mcp.tools.stt import STT_JOB_BASE
+
+_OBSOLETE_BATCH_STT_PATH = "/speech-to-text/job/init"
 
 
 def test_all_languages_have_required_fields():
@@ -40,3 +43,30 @@ def test_pricing_table_covers_every_model_in_reference():
     # Every referenced model must appear in PRICING.
     missing = referenced_models - _data.PRICING.keys()
     assert not missing, f"Pricing entries missing for: {missing}"
+
+
+def test_batch_stt_reference_uses_runtime_job_v1_path():
+    # Builder tables must document the same create-job path the runtime tool calls.
+    assert STT_JOB_BASE == "/speech-to-text/job/v1"
+    job_keys = [key for key in _data.API_REFERENCE if "job" in key]
+    assert STT_JOB_BASE in _data.API_REFERENCE, (
+        f"{STT_JOB_BASE!r} is not a key in API_REFERENCE; job keys present: {job_keys}"
+    )
+    assert _OBSOLETE_BATCH_STT_PATH not in _data.API_REFERENCE, (
+        f"{_OBSOLETE_BATCH_STT_PATH!r} must not remain as the batch-STT reference key"
+    )
+
+
+def test_batch_stt_reference_describes_job_parameters_create_shape():
+    # Create-job is POST {job_parameters} → job_id. SAS URLs come from a later
+    # /upload-files call, not from the create response.
+    ref = _data.API_REFERENCE[STT_JOB_BASE]
+    request_body = ref.get("request_body") or {}
+    response = ref.get("response") or {}
+
+    assert ref.get("method") == "POST"
+    assert "job_parameters" in request_body
+    assert "job_id" in response
+    assert "input_storage_path" not in response
+    assert "output_storage_path" not in response
+

--- a/tests/code/test_recommend_and_validate.py
+++ b/tests/code/test_recommend_and_validate.py
@@ -47,6 +47,14 @@ def test_recommend_returns_unmatched_for_unrelated():
     assert result["matched"] is False
 
 
+def test_recommend_long_audio_points_at_job_v1_not_job_init():
+    result = _recommend("transcribe a long Hindi meeting recording")
+    assert result["matched"]
+    taught = " ".join(str(value) for value in result.values())
+    assert "/speech-to-text/job/v1" in taught
+    assert "/speech-to-text/job/init" not in taught
+
+
 # ---- validate -------------------------------------------------------------
 
 


### PR DESCRIPTION
Fixes #83.

### Summary
The runtime batch STT tools in `sarvam_mcp.tools.stt` use `/speech-to-text/job/v1`, but the developer builder tables in `sarvam_mcp.code` were still documenting the obsolete `/speech-to-text/job/init` endpoint and its legacy flat request/response shape. This PR updates the reference data, endpoint literals, and recommendation heuristics to align with the active runtime API and adds regression tests to ensure consistency.

### Changes
- **`src/sarvam_mcp/code/_data.py`**:
  - Replaced `/speech-to-text/job/init` with `/speech-to-text/job/v1`.
  - Updated `request_body` to document `job_parameters` object (`model`, `mode`, `language_code`, `with_timestamps`, `with_diarization`, `num_speakers`).
  - Updated `response` to return `{ "job_id": "str" }`.
  - Documented the multi-step asynchronous flow in `notes` (`job/v1` -> `upload-files` -> PUT audio to SAS URL -> `start` -> poll `status`/`download-files`).
  - Updated the tip in `/speech-to-text` to point to `/speech-to-text/job/v1`.
- **`src/sarvam_mcp/code/docs.py`**:
  - Updated `EndpointPath` literal type from `"/speech-to-text/job/init"` to `"/speech-to-text/job/v1"`.
- **`src/sarvam_mcp/code/snippets.py`**:
  - Updated `tip_long_audio` in `_recommend()` to point to `/speech-to-text/job/v1`.
- **`tests/code/test_data.py`**:
  - Added `test_batch_stt_reference_uses_runtime_job_v1_path` asserting `STT_JOB_BASE` is present and `/speech-to-text/job/init` is absent.
  - Added `test_batch_stt_reference_describes_job_parameters_create_shape` asserting `job_parameters` is in `request_body` and flat storage paths are absent.
- **`tests/code/test_recommend_and_validate.py`**:
  - Added `test_recommend_long_audio_points_at_job_v1_not_job_init`.

### Test Plan
- [x] Full test suite passes: `uv run pytest` (64 passed)
- [x] Linter passes: `uv run ruff check` on all touched files